### PR TITLE
Node comms rework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ REACT_APP_SITE_URL="https://app.sarcophagus.io/"
 ## Peer discovery configuration
 REACT_APP_BOOTSTRAP_NODE_LIST="/ip4/143.198.182.181/tcp/10000/ws/p2p/12D3KooWAsxUbeyiTv8zr7iURBh2ugajHK2ZsS8Js4Vu3Q3SrLpA"
 REACT_APP_SIGNAL_SERVER_LIST="sig.encryptafile.com"
+REACT_DHT_PROTOCOL_PREFIX="archaeologist-server-test"
 
 ## Sentry configuration
 REACT_APP_SENTRY_DSN=""

--- a/src/features/archaeologist/archaeologistList/SubmitMock.tsx
+++ b/src/features/archaeologist/archaeologistList/SubmitMock.tsx
@@ -34,8 +34,8 @@ export function SubmitMock() {
 
     let shardI = 0;
     for await (const arch of selectedArchaeologists) {
-      archShards[arch.publicKey] = await arweaveService.encryptShard(shards[shardI], arch.publicKey);
-      unencryptedArchShardHashes[arch.address] = solidityKeccak256(['string'], [shards[shardI]]);
+      archShards[arch.publicKey!] = await arweaveService.encryptShard(shards[shardI], arch.publicKey!);
+      unencryptedArchShardHashes[arch.profile.archAddress] = solidityKeccak256(['string'], [shards[shardI]]);
       shardI++;
     }
 
@@ -49,7 +49,7 @@ export function SubmitMock() {
     selectedArchaeologists.forEach(arch => confirmArweaveTransaction({
       arch,
       arweaveTxId,
-      unencryptedShardHash: unencryptedArchShardHashes[arch.address],
+      unencryptedShardHash: unencryptedArchShardHashes[arch.profile.archAddress],
     }));
 
     const archCount = selectedArchaeologists.length;

--- a/src/features/archaeologist/archaeologistList/index.tsx
+++ b/src/features/archaeologist/archaeologistList/index.tsx
@@ -23,8 +23,8 @@ import { useLoadArchaeologists } from '../hooks/useLoadArchaeologists';
 import { ArchaeologistsWarnings } from './ArchaeologistsWarnings';
 import { RequiredArchaeologistsPicker } from './RequiredArchaeologistsPicker';
 import { SubmitMock } from './SubmitMock';
-import { ethers } from 'ethers';
 import { Archaeologist } from 'types';
+import { ethers } from 'ethers';
 
 export function ArchaeologistList() {
   const dispatch = useDispatch();
@@ -71,14 +71,13 @@ export function ArchaeologistList() {
               <Thead>
                 <Tr>
                   <Th>Archaeologists</Th>
-                  <Th>Arweave</Th>
                   <Th isNumeric>Digging Fees</Th>
-                  <Th isNumeric>Bounty</Th>
+                  <Th isNumeric>Online</Th>
                 </Tr>
               </Thead>
               <Tbody>
                 {archaeologists.map(arch => (
-                  <Tr key={arch.address}>
+                  <Tr key={arch.profile.archAddress}>
                     <Td>
                       <Flex>
                         <Checkbox
@@ -87,17 +86,19 @@ export function ArchaeologistList() {
                             handleCheckArchaeologist(arch);
                           }}
                         />
-                        <Text ml={3}>{formatAddress(arch.address)}</Text>
+                        <Text ml={3}>{formatAddress(arch.profile.archAddress)}</Text>
                       </Flex>
                     </Td>
+                    <Td isNumeric >
+                      <Text>{ethers.utils.formatEther(arch.profile.minimumDiggingFee)} SARCO</Text>
+                    </Td>
                     <Td>
-                      <Text>{arch.isArweaver.toString()}</Text>
-                    </Td>
-                    <Td isNumeric>
-                      <Text>{ethers.utils.formatEther(arch.diggingFee)} SARCO</Text>
-                    </Td>
-                    <Td isNumeric>
-                      <Text>{ethers.utils.formatEther(arch.bounty)} SARCO</Text>
+                      <Flex>
+                        <Checkbox
+                          isChecked={arch.isOnline}
+                          isReadOnly
+                        />
+                      </Flex>
                     </Td>
                   </Tr>
                 ))}

--- a/src/features/archaeologist/archaeologistList/index.tsx
+++ b/src/features/archaeologist/archaeologistList/index.tsx
@@ -72,7 +72,7 @@ export function ArchaeologistList() {
                 <Tr>
                   <Th>Archaeologists</Th>
                   <Th isNumeric>Digging Fees</Th>
-                  <Th isNumeric>Online</Th>
+                  <Th isNumeric>Status</Th>
                 </Tr>
               </Thead>
               <Tbody>
@@ -92,13 +92,8 @@ export function ArchaeologistList() {
                     <Td isNumeric >
                       <Text>{ethers.utils.formatEther(arch.profile.minimumDiggingFee)} SARCO</Text>
                     </Td>
-                    <Td>
-                      <Flex>
-                        <Checkbox
-                          isChecked={arch.isOnline}
-                          isReadOnly
-                        />
-                      </Flex>
+                    <Td isNumeric>
+                      <Text>{arch.isOnline ? 'ONLINE' : 'OFFLINE'}</Text>
                     </Td>
                   </Tr>
                 ))}

--- a/src/features/archaeologist/discovery.ts
+++ b/src/features/archaeologist/discovery.ts
@@ -88,10 +88,13 @@ export async function initialisePeerDiscovery(
           const archAddress = archConfigJson.address;
 
           const i = storedArchaeologists.findIndex(a => a.profile.archAddress === archAddress);
-          const arch = storedArchaeologists[i];
-          arch.publicKey = archConfigJson.encryptionPublicKey;
 
-          callbacks.onArchConnected(arch);
+          if (i !== -1) {
+            const arch = storedArchaeologists[i];
+            arch.publicKey = archConfigJson.encryptionPublicKey;
+
+            callbacks.onArchConnected(arch);
+          }
         }
       }
     ).finally(() => {

--- a/src/features/archaeologist/hooks/useLoadArchaeologists.ts
+++ b/src/features/archaeologist/hooks/useLoadArchaeologists.ts
@@ -2,7 +2,7 @@ import { useGetArchaeologistProfiles } from 'hooks/viewStateFacet';
 import { LibP2pContext } from 'lib/network/P2PNodeProvider';
 import { useContext } from 'react';
 import { useAsyncEffect } from '../../../hooks/useAsyncEffect';
-import { useDispatch } from '../../../store';
+import { useDispatch, useSelector } from '../../../store';
 import { storeArchaeologists, selectArchaeologist } from '../../../store/archaeologist/actions';
 import { Archaeologist } from '../../../types';
 import { initialisePeerDiscovery } from '../discovery';
@@ -12,23 +12,29 @@ export function useLoadArchaeologists() {
 
   useGetArchaeologistProfiles();
 
+  const storedArchaeologists = useSelector(s => s.archaeologistState.archaeologists);
+
   const browserNode = useContext(LibP2pContext);
   useAsyncEffect(async () => {
     try {
+      console.log('storedArchaeologists', storedArchaeologists);
+
       if (browserNode === undefined) {
         console.error('browser node is undefined');
         return;
       }
 
-      await initialisePeerDiscovery(
-        await browserNode, {
-        setArchs: (discoveredArchs: Archaeologist[]) => dispatch(storeArchaeologists(discoveredArchs)),
-        onArchConnected: (connectedArc: Archaeologist) => dispatch(selectArchaeologist(connectedArc)),
+      if (storedArchaeologists.length > 0) {
+        await initialisePeerDiscovery(
+          await browserNode,
+          storedArchaeologists, {
+          setArchs: (discoveredArchs: Archaeologist[]) => dispatch(storeArchaeologists(discoveredArchs)),
+          onArchConnected: (connectedArc: Archaeologist) => dispatch(selectArchaeologist(connectedArc)),
+        });
       }
-      );
     } catch (error) {
       // TODO: Implement better error handling
       console.error(error);
     }
-  }, []);
+  }, [storedArchaeologists]);
 }

--- a/src/hooks/embalmerFacet/useInitializeSarcophagus.ts
+++ b/src/hooks/embalmerFacet/useInitializeSarcophagus.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 import { EmbalmerFacet } from 'lib/abi/EmbalmerFacet';
-import { ContractArchaeologist } from 'types';
+import { SelectedContractArchaeologist } from 'types';
 import { useSubmitTransaction } from '../useSubmitTransactions';
 
 interface InitializeSarcophagusArgs {
@@ -10,8 +10,8 @@ interface InitializeSarcophagusArgs {
   resurrectionTime: number;
   canBeTransferred: boolean;
   minShards: number;
-  archaeologists: ContractArchaeologist[];
-  arweaveArchaeologist: ContractArchaeologist;
+  archaeologists: SelectedContractArchaeologist[];
+  arweaveArchaeologist: SelectedContractArchaeologist;
 }
 
 export function useInitializeSarcophagus({

--- a/src/hooks/useArweaveService.ts
+++ b/src/hooks/useArweaveService.ts
@@ -76,6 +76,7 @@ const useArweaveService = () => {
       dq: 'wOg4z_7ndHXhl0D2-TS5UE1Ygw5oowj3aWIvFlt9Fgsj4lSP6fhzU46_zjIA-Z3ccnIuka9J3tZLbaoIKDME92nV7GNna_h_-cdGegSLeqrE4t2Lz4xUSxFYiMuWdlVkpqjZysakl9qjDTpzR2q4005UrymTYsljV0tjbHH_1A1enB3MuXEvs37r7R_Hl0B9YG8lIl2ZZ7MAjuQGe4RczOqr9Cn5aUX1M5gIyikEdKX7IaLF2Nndyb6GQTPDhOXM0uLCprQ0uv6vKJOSEbMe4L5jF_PTUIGu-z6RbsXEE_ovISuJH4XshDxqX2gP-4IlfqAZ2FDxEXMC7DrXHg3KoQ',
       qi: 'kS2AXYKfVKOdtNGiksIgs2YT4Pz-62rCeynyFlnUDc6E3eylzctLHhuWMRqWqnPwVPwnw2Fd6eUTOYZe82kVf9d0-XbeDtOOP6fS7HU30ICIvFrLTiaVEsLekUdQwoyC7s0xH99FZpdGJHzC7iNdlChybmrh4Ci5OyOLn_o8goNQBYWEXOgr6JgJLTh9BXvDEbNLLJ0JTZFQeLVqQeimPDSoAwBFCLBBwOd6CFOr5wTc9Pkt8cDrpcf9usU-61uu3Lr4-3PG4yUUQyphnDy84DgpUyuF5JNy0KgtuZaMMuAZJTb_gKN3IdLUHV9phqwrSKylLn-enGJ0f4FTpfcDEQ',
     };
+    // address: Xm17-cZJjcx-jc_UL5me1o5nfqC2T1mF-yu03gmKeK4
 
     const tx = await arweave.createTransaction({ data: file }, key);
     tx.addTag('Content-Type', 'plain/text');

--- a/src/hooks/viewStateFacet/index.ts
+++ b/src/hooks/viewStateFacet/index.ts
@@ -11,3 +11,4 @@ export { useGetRecipientSarcophagi } from './useGetRecipientSarcophagi';
 export { useGetSarcophagus } from './useGetSarcophagus';
 export { useGetSarcophagusArchaeologist } from './useGetSarcophagusArchaeologist';
 export { useGetTotalProtocolFees } from './useGetTotalProtocolFees';
+export { useGetArchaeologistProfiles } from './useGetArchaeologistProfiles';

--- a/src/hooks/viewStateFacet/useGetArchaeologistProfiles.ts
+++ b/src/hooks/viewStateFacet/useGetArchaeologistProfiles.ts
@@ -5,14 +5,13 @@ import { useNetworkConfig } from 'lib/config';
 import { ArchaeologistProfile } from 'types';
 import { useAsyncEffect } from 'hooks/useAsyncEffect';
 import { useDispatch } from '../../store';
-import { startLoad, stopLoad } from 'store/app/actions';
 import { storeArchaeologists } from 'store/archaeologist/actions';
 
 export function useGetArchaeologistProfiles() {
   const networkConfig = useNetworkConfig();
   const dispatch = useDispatch();
 
-  dispatch(startLoad());
+  // dispatch(startLoad());
   const { data: addresses, isLoading: loadingAddresses } = useContractRead({
     addressOrName: networkConfig.diamondDeployAddress,
     contractInterface: ViewStateFacet.abi,
@@ -26,18 +25,12 @@ export function useGetArchaeologistProfiles() {
     if (!loadingAddresses && addresses) {
       // TODO: Having to do single use `readContract`s in a loop because `useContractReads` does not work in hardhat
       for await (const addr of addresses) {
-
-        console.log('addresses', addresses[0]);
-        console.log('addr', addr);
-
         const profile = await readContract({
           addressOrName: networkConfig.diamondDeployAddress,
           contractInterface: ViewStateFacet.abi,
           functionName: 'getArchaeologistProfile',
           args: [addr],
         });
-
-        console.log('profile', profile);
 
         if (profile) {
           profiles.push({
@@ -60,7 +53,7 @@ export function useGetArchaeologistProfiles() {
       const archaeologists = profiles.map(profile => ({ profile, isOnline: false }));
 
       dispatch(storeArchaeologists(archaeologists));
-      dispatch(stopLoad());
+      // dispatch(stopLoad());
     }
 
   }, [loadingAddresses, addresses]);

--- a/src/hooks/viewStateFacet/useGetArchaeologistProfiles.ts
+++ b/src/hooks/viewStateFacet/useGetArchaeologistProfiles.ts
@@ -1,0 +1,76 @@
+import { useContractRead } from 'wagmi';
+import { readContract } from 'wagmi/actions';
+import { ViewStateFacet } from 'lib/abi/ViewStateFacet';
+import { useNetworkConfig } from 'lib/config';
+import { ArchaeologistProfile } from 'types';
+import { useAsyncEffect } from 'hooks/useAsyncEffect';
+import { useDispatch } from '../../store';
+import { startLoad, stopLoad } from 'store/app/actions';
+import { storeArchaeologists } from 'store/archaeologist/actions';
+
+export function useGetArchaeologistProfiles() {
+  const networkConfig = useNetworkConfig();
+  const dispatch = useDispatch();
+
+  dispatch(startLoad());
+  const { data: addresses, isLoading: loadingAddresses } = useContractRead({
+    addressOrName: networkConfig.diamondDeployAddress,
+    contractInterface: ViewStateFacet.abi,
+    functionName: 'getArchaeologistProfileAddresses',
+  });
+
+  // const config: ReadContractsConfig = { contracts: [] };
+  let profiles: ArchaeologistProfile[] = [];
+
+  useAsyncEffect(async () => {
+    if (!loadingAddresses && addresses) {
+      // TODO: Having to do single use `readContract`s in a loop because `useContractReads` does not work in hardhat
+      for await (const addr of addresses) {
+
+        console.log('addresses', addresses[0]);
+        console.log('addr', addr);
+
+        const profile = await readContract({
+          addressOrName: networkConfig.diamondDeployAddress,
+          contractInterface: ViewStateFacet.abi,
+          functionName: 'getArchaeologistProfile',
+          args: [addr],
+        });
+
+        console.log('profile', profile);
+
+        if (profile) {
+          profiles.push({
+            archAddress: addr,
+            exists: profile.exists,
+            minimumDiggingFee: profile.minimumDiggingFee,
+            maximumRewrapInterval: profile.maximumRewrapInterval,
+            peerId: profile.peerId,
+          });
+        }
+
+        // config.contracts.push({
+        //   addressOrName: networkConfig.diamondDeployAddress,
+        //   contractInterface: ViewStateFacet.abi,
+        //   functionName: 'getArchaeologistProfile',
+        //   args: [addr],
+        // });
+      }
+
+      const archaeologists = profiles.map(profile => ({ profile, isOnline: false }));
+
+      dispatch(storeArchaeologists(archaeologists));
+      dispatch(stopLoad());
+    }
+
+  }, [loadingAddresses, addresses]);
+
+  // const { data, isLoading: loadingProfiles } = useContractReads(config);
+  // profiles = data?.map((d, i) => ({
+  //   archAddress: addresses![i],
+  //   exists: d.exists,
+  //   minimumDiggingFee: d.minimumDiggingFee,
+  //   maximumRewrapInterval: d.maximumRewrapInterval,
+  //   peerId: d.peerId,
+  // })) ?? [];
+}

--- a/src/lib/abi/ArchaeologistFacet.ts
+++ b/src/lib/abi/ArchaeologistFacet.ts
@@ -433,6 +433,11 @@ export const ArchaeologistFacet = {
           name: 'freeBond',
           type: 'uint256',
         },
+        {
+          internalType: 'string',
+          name: 'peerId',
+          type: 'string',
+        },
       ],
       name: 'registerArchaeologist',
       outputs: [],

--- a/src/lib/abi/ArchaeologistFacet.ts
+++ b/src/lib/abi/ArchaeologistFacet.ts
@@ -25,6 +25,22 @@ export const ArchaeologistFacet = {
     {
       inputs: [
         {
+          internalType: 'bool',
+          name: 'exists',
+          type: 'bool',
+        },
+        {
+          internalType: 'address',
+          name: 'archaeologist',
+          type: 'address',
+        },
+      ],
+      name: 'ArchaeologistProfileExistsShouldBe',
+      type: 'error',
+    },
+    {
+      inputs: [
+        {
           internalType: 'uint256',
           name: 'cursedBond',
           type: 'uint256',
@@ -233,6 +249,37 @@ export const ArchaeologistFacet = {
       inputs: [
         {
           indexed: true,
+          internalType: 'address',
+          name: 'archaeologist',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'minimumDiggingFee',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'maximumRewrapInterval',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'freeBond',
+          type: 'uint256',
+        },
+      ],
+      name: 'RegisterArchaeologist',
+      type: 'event',
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
           internalType: 'bytes32',
           name: 'sarcoId',
           type: 'bytes32',
@@ -245,6 +292,37 @@ export const ArchaeologistFacet = {
         },
       ],
       name: 'UnwrapSarcophagus',
+      type: 'event',
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'archaeologist',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'minimumDiggingFee',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'maximumRewrapInterval',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'freeBond',
+          type: 'uint256',
+        },
+      ],
+      name: 'UpdateArchaeologist',
       type: 'event',
     },
     {
@@ -341,6 +419,29 @@ export const ArchaeologistFacet = {
     {
       inputs: [
         {
+          internalType: 'uint256',
+          name: 'minimumDiggingFee',
+          type: 'uint256',
+        },
+        {
+          internalType: 'uint256',
+          name: 'maximumRewrapInterval',
+          type: 'uint256',
+        },
+        {
+          internalType: 'uint256',
+          name: 'freeBond',
+          type: 'uint256',
+        },
+      ],
+      name: 'registerArchaeologist',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function',
+    },
+    {
+      inputs: [
+        {
           internalType: 'bytes32',
           name: 'sarcoId',
           type: 'bytes32',
@@ -352,6 +453,29 @@ export const ArchaeologistFacet = {
         },
       ],
       name: 'unwrapSarcophagus',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function',
+    },
+    {
+      inputs: [
+        {
+          internalType: 'uint256',
+          name: 'minimumDiggingFee',
+          type: 'uint256',
+        },
+        {
+          internalType: 'uint256',
+          name: 'maximumRewrapInterval',
+          type: 'uint256',
+        },
+        {
+          internalType: 'uint256',
+          name: 'freeBond',
+          type: 'uint256',
+        },
+      ],
+      name: 'updateArchaeologist',
       outputs: [],
       stateMutability: 'nonpayable',
       type: 'function',

--- a/src/lib/abi/EmbalmerFacet.ts
+++ b/src/lib/abi/EmbalmerFacet.ts
@@ -479,18 +479,13 @@ export const EmbalmerFacet = {
               type: 'uint256',
             },
             {
-              internalType: 'uint256',
-              name: 'bounty',
-              type: 'uint256',
-            },
-            {
               internalType: 'bytes32',
               name: 'hashedShard',
               type: 'bytes32',
             },
           ],
-          internalType: 'struct LibTypes.ArchaeologistMemory[]',
-          name: 'archaeologists',
+          internalType: 'struct LibTypes.SelectedArchaeologistMemory[]',
+          name: 'selectedArchaeologists',
           type: 'tuple[]',
         },
         {

--- a/src/lib/abi/ViewStateFacet.ts
+++ b/src/lib/abi/ViewStateFacet.ts
@@ -45,18 +45,77 @@ export const ViewStateFacet = {
           name: 'archaeologist',
           type: 'address',
         },
-        {
-          internalType: 'bytes32',
-          name: 'sarcoId',
-          type: 'bytes32',
-        },
       ],
-      name: 'getArchaeologistSuccessOnSarcophagus',
+      name: 'getArchaeologistProfile',
       outputs: [
         {
-          internalType: 'bool',
+          components: [
+            {
+              internalType: 'bool',
+              name: 'exists',
+              type: 'bool',
+            },
+            {
+              internalType: 'uint256',
+              name: 'minimumDiggingFee',
+              type: 'uint256',
+            },
+            {
+              internalType: 'uint256',
+              name: 'maximumRewrapInterval',
+              type: 'uint256',
+            },
+            {
+              internalType: 'uint256',
+              name: 'freeBond',
+              type: 'uint256',
+            },
+            {
+              internalType: 'uint256',
+              name: 'cursedBond',
+              type: 'uint256',
+            },
+            {
+              internalType: 'uint256',
+              name: 'rewards',
+              type: 'uint256',
+            },
+          ],
+          internalType: 'struct LibTypes.ArchaeologistProfile',
           name: '',
-          type: 'bool',
+          type: 'tuple',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+    {
+      inputs: [
+        {
+          internalType: 'uint256',
+          name: 'index',
+          type: 'uint256',
+        },
+      ],
+      name: 'getArchaeologistProfileAddressAtIndex',
+      outputs: [
+        {
+          internalType: 'address',
+          name: '',
+          type: 'address',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+    {
+      inputs: [],
+      name: 'getArchaeologistProfileAddresses',
+      outputs: [
+        {
+          internalType: 'address[]',
+          name: '',
+          type: 'address[]',
         },
       ],
       stateMutability: 'view',
@@ -70,12 +129,36 @@ export const ViewStateFacet = {
           type: 'address',
         },
       ],
-      name: 'getArchaeologistsarcophagi',
+      name: 'getArchaeologistSarcophagi',
       outputs: [
         {
           internalType: 'bytes32[]',
           name: '',
           type: 'bytes32[]',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+    {
+      inputs: [
+        {
+          internalType: 'address',
+          name: 'archaeologist',
+          type: 'address',
+        },
+        {
+          internalType: 'bytes32',
+          name: 'sarcoId',
+          type: 'bytes32',
+        },
+      ],
+      name: 'getArchaeologistSuccessOnSarcophagus',
+      outputs: [
+        {
+          internalType: 'bool',
+          name: '',
+          type: 'bool',
         },
       ],
       stateMutability: 'view',
@@ -127,7 +210,7 @@ export const ViewStateFacet = {
           type: 'address',
         },
       ],
-      name: 'getEmbalmersarcophagi',
+      name: 'getEmbalmerSarcophagi',
       outputs: [
         {
           internalType: 'bytes32[]',
@@ -178,7 +261,7 @@ export const ViewStateFacet = {
           type: 'address',
         },
       ],
-      name: 'getRecipientsarcophagi',
+      name: 'getRecipientSarcophagi',
       outputs: [
         {
           internalType: 'bytes32[]',
@@ -290,11 +373,6 @@ export const ViewStateFacet = {
             {
               internalType: 'uint256',
               name: 'diggingFee',
-              type: 'uint256',
-            },
-            {
-              internalType: 'uint256',
-              name: 'bounty',
               type: 'uint256',
             },
             {

--- a/src/lib/abi/ViewStateFacet.ts
+++ b/src/lib/abi/ViewStateFacet.ts
@@ -80,6 +80,11 @@ export const ViewStateFacet = {
               name: 'rewards',
               type: 'uint256',
             },
+            {
+              internalType: 'string',
+              name: 'peerId',
+              type: 'string',
+            },
           ],
           internalType: 'struct LibTypes.ArchaeologistProfile',
           name: '',

--- a/src/lib/utils/node_config.ts
+++ b/src/lib/utils/node_config.ts
@@ -1,6 +1,5 @@
 import { Noise } from '@chainsafe/libp2p-noise';
 import { Mplex } from '@libp2p/mplex';
-import { Bootstrap } from '@libp2p/bootstrap';
 import { KadDHT } from '@libp2p/kad-dht';
 import { WebRTCStar } from '@libp2p/webrtc-star';
 
@@ -33,13 +32,10 @@ export const nodeConfig = {
   ],
   peerDiscovery: [
     webRtcStar.discovery,
-    new Bootstrap({
-      list: process.env.REACT_APP_BOOTSTRAP_NODE_LIST!.split(',').map((s: string) => s.trim())
-    }),
   ],
   dht,
   connectionManager: {
-    autoDial: true
+    autoDial: false
   },
   pubsub: new FloodSub({
     enabled: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,22 +6,16 @@ export interface ChildrenOnly {
 }
 
 export interface Archaeologist {
-  publicKey: string;
-  address: string;
-  bounty: BigNumber;
-  diggingFee: BigNumber;
-  isArweaver: boolean;
-  feePerByte: BigNumber;
-  maxResurrectionTime: number;
+  publicKey?: string;
+  profile: ContractArchaeologist;
   connection?: any;
 }
 
 export interface ContractArchaeologist {
   archAddress: string;
-  storageFee: BigNumber;
   diggingFee: BigNumber;
-  bounty: BigNumber;
-  hashedShard: string;
+  maxResurrectionInterval: number;
+  hashedShard?: string;
 }
 
 export interface SignatureWithAccount extends Signature {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,15 +7,24 @@ export interface ChildrenOnly {
 
 export interface Archaeologist {
   publicKey?: string;
-  profile: ContractArchaeologist;
+  profile: ArchaeologistProfile;
   connection?: any;
+  isOnline: boolean;
 }
 
-export interface ContractArchaeologist {
+export interface SelectedContractArchaeologist {
   archAddress: string;
   diggingFee: BigNumber;
-  maxResurrectionInterval: number;
+  storageFee: BigNumber;
   hashedShard?: string;
+}
+
+export interface ArchaeologistProfile {
+  archAddress: string,
+  exists: boolean;
+  minimumDiggingFee: BigNumber;
+  maximumRewrapInterval: number;
+  peerId: string;
 }
 
 export interface SignatureWithAccount extends Signature {


### PR DESCRIPTION
This PR implements the first phase of the ongoing node communications rework. The webapp will fetch archaeologist addresses from the contracts, then use those addresses to fetch their profiles.

These profiles are saved with an additional and default `offline` flag. Upon node discovery, they are then set to online so the user is aware they can be communicated with.

***Notes:***

- Replaced pubsub comms with direct streaming
- autodial flag set to false
- Updates to Archaeologist interfaces
- Initial work on 2nd phase of handshake -- expect JSON config object received on connect to have a signature as well. Address is validated from this signature as proof of identity.

---

I really struggled with keeping the code readable and in-structure with this one, especially with my limited understanding of the hooks pattern. The logic works, but plz _plz_ suggest improvements during review 