### PR TITLE
72 add multicall for arch profiles

### DIFF
--- a/src/features/embalm/stepContent/hooks/useLoadArchaeologists.ts
+++ b/src/features/embalm/stepContent/hooks/useLoadArchaeologists.ts
@@ -4,7 +4,6 @@ import { useEffect } from 'react';
 import { startLoad, stopLoad } from 'store/app/actions';
 import { setArchaeologists } from 'store/embalm/actions';
 import { useDispatch, useSelector } from 'store/index';
-import { ArchaeologistProfile } from 'types';
 import { readContract } from 'wagmi/actions';
 
 /**
@@ -24,41 +23,25 @@ export function useLoadArchaeologists() {
         if (archaeologists.length > 0) return;
         dispatch(startLoad());
 
-        let profiles: Record<string, ArchaeologistProfile> = {};
-
         const addresses: string[] = await readContract({
           addressOrName: networkConfig.diamondDeployAddress,
           contractInterface: ViewStateFacet.abi,
           functionName: 'getArchaeologistProfileAddresses',
         });
+        if (!addresses) return;
 
-        if (addresses) {
-          // TODO: Having to do single use `readContract`s in a loop because `useContractReads` does not work in hardhat
-          for await (const addr of addresses) {
-            const profile: ArchaeologistProfile = await readContract({
-              addressOrName: networkConfig.diamondDeployAddress,
-              contractInterface: ViewStateFacet.abi,
-              functionName: 'getArchaeologistProfile',
-              args: [addr],
-            });
+        const profiles = await readContract({
+          addressOrName: networkConfig.diamondDeployAddress,
+          contractInterface: ViewStateFacet.abi,
+          functionName: 'getArchaeologistProfiles',
+          args: [addresses],
+        });
 
-            if (profile) {
-              profiles[addr] = {
-                archAddress: addr,
-                exists: profile.exists,
-                minimumDiggingFee: profile.minimumDiggingFee,
-                maximumRewrapInterval: profile.maximumRewrapInterval,
-                peerId: profile.peerId,
-              };
-            }
-          }
-
-          const newArchaeologists = Object.values(profiles).map(p => ({
-            profile: p,
-            isOnline: false,
-          }));
-          dispatch(setArchaeologists(newArchaeologists));
-        }
+        const newArchaeologists = profiles.map((p, i) => ({
+          profile: { ...p, archAddress: addresses[i] },
+          isOnline: false,
+        }));
+        dispatch(setArchaeologists(newArchaeologists));
       } catch (error) {
         console.error(error);
       } finally {

--- a/src/lib/abi/ViewStateFacet.ts
+++ b/src/lib/abi/ViewStateFacet.ts
@@ -80,11 +80,6 @@ export const ViewStateFacet = {
               name: 'cursedBond',
               type: 'uint256',
             },
-            {
-              internalType: 'uint256',
-              name: 'rewards',
-              type: 'uint256',
-            },
           ],
           internalType: 'struct LibTypes.ArchaeologistProfile',
           name: '',
@@ -129,6 +124,57 @@ export const ViewStateFacet = {
     {
       inputs: [
         {
+          internalType: 'address[]',
+          name: 'addresses',
+          type: 'address[]',
+        },
+      ],
+      name: 'getArchaeologistProfiles',
+      outputs: [
+        {
+          components: [
+            {
+              internalType: 'bool',
+              name: 'exists',
+              type: 'bool',
+            },
+            {
+              internalType: 'string',
+              name: 'peerId',
+              type: 'string',
+            },
+            {
+              internalType: 'uint256',
+              name: 'minimumDiggingFee',
+              type: 'uint256',
+            },
+            {
+              internalType: 'uint256',
+              name: 'maximumRewrapInterval',
+              type: 'uint256',
+            },
+            {
+              internalType: 'uint256',
+              name: 'freeBond',
+              type: 'uint256',
+            },
+            {
+              internalType: 'uint256',
+              name: 'cursedBond',
+              type: 'uint256',
+            },
+          ],
+          internalType: 'struct LibTypes.ArchaeologistProfile[]',
+          name: '',
+          type: 'tuple[]',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+    {
+      inputs: [
+        {
           internalType: 'address',
           name: 'archaeologist',
           type: 'address',
@@ -164,25 +210,6 @@ export const ViewStateFacet = {
           internalType: 'bool',
           name: '',
           type: 'bool',
-        },
-      ],
-      stateMutability: 'view',
-      type: 'function',
-    },
-    {
-      inputs: [
-        {
-          internalType: 'address',
-          name: 'archaeologist',
-          type: 'address',
-        },
-      ],
-      name: 'getAvailableRewards',
-      outputs: [
-        {
-          internalType: 'uint256',
-          name: '',
-          type: 'uint256',
         },
       ],
       stateMutability: 'view',
@@ -247,7 +274,7 @@ export const ViewStateFacet = {
     },
     {
       inputs: [],
-      name: 'getProtocolFeeAmount',
+      name: 'getProtocolFeeBasePercentage',
       outputs: [
         {
           internalType: 'uint256',
@@ -272,6 +299,25 @@ export const ViewStateFacet = {
           internalType: 'bytes32[]',
           name: '',
           type: 'bytes32[]',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+    {
+      inputs: [
+        {
+          internalType: 'address',
+          name: 'archaeologist',
+          type: 'address',
+        },
+      ],
+      name: 'getRewards',
+      outputs: [
+        {
+          internalType: 'uint256',
+          name: '',
+          type: 'uint256',
         },
       ],
       stateMutability: 'view',


### PR DESCRIPTION
# Get all arch profiles

In order to get this PR to work you must pull down the branch in the contracts. https://github.com/sarcophagus-org/sarcophagus-v2-contracts/compare/64-add-a-function-in-the-viewstatefacet-to-get-all-archaeologist-profiles?expand=1

Gets all arch profiles in a single call.

This PR is rebased on #69.

