### PR TITLE
Error Handling

### DIFF
--- a/src/features/embalm/stepContent/hooks/useBundlr.ts
+++ b/src/features/embalm/stepContent/hooks/useBundlr.ts
@@ -96,13 +96,9 @@ export function useBundlr() {
         toast(uploadSuccess());
         return res.data.id;
       } catch (_error) {
-        const error = _error as Error;
-        console.error(error);
-        toast(uploadFailure(error.message));
-      } finally {
         setIsUploading(false);
+        throw _error;
       }
-      return '';
     },
     [bundlr, toast]
   );

--- a/src/features/embalm/stepContent/hooks/useBundlr.ts
+++ b/src/features/embalm/stepContent/hooks/useBundlr.ts
@@ -4,7 +4,6 @@ import {
   fundFailure,
   fundStart,
   fundSuccess,
-  uploadFailure,
   uploadStart,
   uploadSuccess,
   withdrawFailure,

--- a/src/features/embalm/stepContent/hooks/useBundlr.ts
+++ b/src/features/embalm/stepContent/hooks/useBundlr.ts
@@ -23,7 +23,6 @@ export function useBundlr() {
 
   // Used to tell the component when to render loading circle
   const [isWithdrawing, setIsWithdrawing] = useState(false);
-  const [isUploading, setIsUploading] = useState(false);
 
   /**
    * Funds the bundlr node
@@ -88,14 +87,12 @@ export function useBundlr() {
         throw new Error('Bundlr not connected');
       }
 
-      setIsUploading(true);
       toast(uploadStart());
       try {
         const res = await bundlr?.upload(fileBuffer);
         toast(uploadSuccess());
         return res.data.id;
       } catch (_error) {
-        setIsUploading(false);
         throw _error;
       }
     },
@@ -108,7 +105,6 @@ export function useBundlr() {
     isConnected,
     isFunding,
     isWithdrawing,
-    isUploading,
     fund,
     withdraw,
     uploadFile,

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus.ts
@@ -317,6 +317,7 @@ export function useCreateSarcophagus() {
             case CreateSarcophagusStage.APPROVE:
               await executeStage(approve)
                 .catch(e => {
+                  console.log(e);
                   let friendlyError = e.reason ? handleContractCallException(e.reason) : 'Failed to approve';
                   setStageError(friendlyError);
                 });
@@ -324,16 +325,11 @@ export function useCreateSarcophagus() {
 
             case CreateSarcophagusStage.SUBMIT_SARCOPHAGUS:
               if (submitSarcophagus) {
-                if (hasApproved) {
-                  await executeStage(submitSarcophagus)
-                    .catch(e => {
-                      let friendlyError = e.reason ? handleContractCallException(e.reason) : 'Failed to submit sarcophagus to contract';
-                      setStageError(friendlyError);
-                    });
-                } else {
-                  setStageExecuting(false);
-                  setStageError('You need to approved SARCO spending');
-                }
+                await executeStage(submitSarcophagus)
+                  .catch(e => {
+                    let friendlyError = e.reason ? handleContractCallException(e.reason) : 'Failed to submit sarcophagus to contract';
+                    setStageError(friendlyError);
+                  });
               }
               break;
 

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { split } from 'shamirs-secret-sharing-ts';
 import { useDispatch, useSelector } from 'store/index';
 import { useSubmitSarcophagus } from 'hooks/embalmerFacet';
-import { ArchaeologistEncryptedShard } from 'types';
+import { Archaeologist, ArchaeologistEncryptedShard } from 'types';
 import useArweaveService from 'hooks/useArweaveService';
 import { createEncryptionKeypairAsync } from './useCreateEncryptionKeypair';
 import { useBundlr } from './useBundlr';
@@ -133,6 +133,8 @@ export function useCreateSarcophagus() {
     console.error(error);
     if (error.isFromArweave) {
       // TODO: need to determine if `error` is arweave error, process accordingly
+    } else if (error.message) {
+      throw new Error(error.message);
     } else {
       // All other errors are unexpected and cannot be handled by the user.
       throw new Error('Something went wrong');
@@ -189,6 +191,12 @@ export function useCreateSarcophagus() {
     }
   }, [file, outerPublicKey, recipientState.publicKey, uploadToArweave, setSarcophagusPayloadTxId]);
 
+  interface ArchCommsExceptionParams {
+    message: string;
+    offendingArchs: Archaeologist[];
+    sourceStage: CreateSarcophagusStage;
+  }
+
   // TODO -- re-enable once figure out state issue at end of createSarcophagus
   // const resetLocalEmbalmerState = useCallback(() => {
   //   setArchaeologistShards([] as ArchaeologistEncryptedShard[]);
@@ -200,23 +208,40 @@ export function useCreateSarcophagus() {
   //   setOuterPublicKey('');
   // }, []);
 
-  // TODO -- add approval stage
+  const incrementStage = useCallback((forceIndex?: number): void => {
+    const stages = Object.keys(createSarcophagusStages).map(i => Number.parseInt(i));
+    const currentIndex = stages.indexOf(currentStage);
+
+    let nextIndex = forceIndex ?? currentIndex + 1;
+
+    // Skip approval step if already approved and about to move into that step
+    if (!forceIndex && currentIndex === CreateSarcophagusStage.APPROVE - 1 && hasApproved) {
+      nextIndex = currentIndex + 2;
+    }
+
+    setCurrentStage(stages[nextIndex]);
+  }, [currentStage, hasApproved]);
+
+  const processArchCommsException = useCallback(({ message, offendingArchs, sourceStage }: ArchCommsExceptionParams) => {
+    // This is only a problem if `offendingArchs` is not empty. If empty, we simply haven't yet heard back from some of them.
+    // We might consider implementing a timeout of sorts, to avoid waiting too long if no exceptions are thrown but no response ever comes in.
+    if (!!offendingArchs.length) {
+      incrementStage(sourceStage);
+      setStageError(message);
+
+      // TODO: Point out offending archs: Some might have declined, others may have connection issues. What should the user do??
+      console.log(
+        message,
+        offendingArchs.map(
+          a => `${a.profile.peerId}:\n ${a.exception!.code}: ${a.exception!.message}`
+        )
+      );
+    }
+  }, [incrementStage]);
+
+  // Process each stage as they become active
   useEffect(() => {
     (async () => {
-      const incrementStage = (): void => {
-        const stages = Object.keys(createSarcophagusStages).map(i => Number.parseInt(i));
-        const currentIndex = stages.indexOf(currentStage);
-
-        let nextIndex = currentIndex + 1;
-
-        // Skip approval step if already approved and about to move into that step
-        if (currentIndex === CreateSarcophagusStage.APPROVE - 1 && hasApproved) {
-          nextIndex = currentIndex + 2;
-        }
-
-        setCurrentStage(stages[nextIndex]);
-      };
-
       const executeStage = async (
         stageToExecute: (...args: any[]) => Promise<any>,
         ...stageArgs: any[]
@@ -254,14 +279,12 @@ export function useCreateSarcophagus() {
                 const offendingArchs = selectedArchaeologists.filter(
                   arch => arch.exception !== undefined
                 );
-                console.log(
-                  'Not all selected archaeologists have responded',
-                  offendingArchs.map(a => `${a.profile.peerId}: ${a.exception!.message}`)
-                );
-                // This is only a problem if `offendingArchs` is not empty. If empty, we simply haven't yet heard back from some of them.
-                // We might consider implementing a timeout of sorts, to avoid waiting too long if no exceptions are thrown but no response ever comes in.
 
-                // TODO: Point out offending archs -- what should the user do??
+                processArchCommsException({
+                  offendingArchs,
+                  sourceStage: CreateSarcophagusStage.DIAL_ARCHAEOLOGISTS,
+                  message: 'Not all selected archaeologists responded',
+                });
               }
               break;
 
@@ -282,16 +305,12 @@ export function useCreateSarcophagus() {
                 const offendingArchs = selectedArchaeologists.filter(
                   arch => arch.exception !== undefined
                 );
-                console.log(
-                  'Not all selected archaeologists have signed off',
-                  offendingArchs.map(
-                    a => `${a.profile.peerId}:\n ${a.exception!.code}: ${a.exception!.message}`
-                  )
-                );
-                // This is only a problem if `offendingArchs` is not empty. If empty, we simply haven't yet heard back from some of them.
-                // We might consider implementing a timeout of sorts, to avoid waiting too long if no exceptions are thrown but no response ever comes in.
 
-                // TODO: Point out offending archs: Some might have declined, others may have connection issues. Check `exception.code` on each to determine exception type -- what should the user do??
+                processArchCommsException({
+                  offendingArchs,
+                  sourceStage: CreateSarcophagusStage.ARCHAEOLOGIST_NEGOTIATION,
+                  message: 'Not all selected archaeologists signed off',
+                });
               }
               break;
 
@@ -354,7 +373,9 @@ export function useCreateSarcophagus() {
     navigate,
     approve,
     allowance,
-    hasApproved
+    hasApproved,
+    incrementStage,
+    processArchCommsException
   ]);
 
   // Update archaeologist public keys, signatures ready status

--- a/src/hooks/useSubmitTransaction.ts
+++ b/src/hooks/useSubmitTransaction.ts
@@ -53,6 +53,6 @@ export function useSubmitTransaction(
   });
 
   return {
-    submit: writeAsync
+    submit: async () => (await writeAsync()).wait()
   };
 }

--- a/src/store/bundlr/actions.ts
+++ b/src/store/bundlr/actions.ts
@@ -10,7 +10,6 @@ export enum ActionType {
   SetBundlr = 'BUNDLR_SET',
   SetBalance = 'EMBALM_SET_BALANCE',
   SetIsFunding = 'EMBALM_SET_IS_FUNDING',
-  SetIsUploading = 'EMBALM_SET_IS_UPLOADING',
   SetPendingBalance = 'EMBALM_SET_PENDING_BALANCE',
   SetTxId = 'BUNDLR_SET_TX_ID',
 }
@@ -20,7 +19,6 @@ type BundlrPayload = {
   [ActionType.Disconnect]: {};
   [ActionType.SetBundlr]: { bundlr: WebBundlr | null };
   [ActionType.SetBalance]: { balance: string };
-  [ActionType.SetIsUploading]: { isUploading: boolean };
   [ActionType.SetIsFunding]: { isFunding: boolean };
   [ActionType.SetPendingBalance]: { pendingBalance: BundlrPendingBalance };
   [ActionType.SetTxId]: { txId: string };
@@ -54,15 +52,6 @@ export function setBalance(balance: string): BundlrActions {
     type: ActionType.SetBalance,
     payload: {
       balance,
-    },
-  };
-}
-
-export function setIsUploading(isUploading: boolean): BundlrActions {
-  return {
-    type: ActionType.SetIsUploading,
-    payload: {
-      isUploading,
     },
   };
 }

--- a/src/store/bundlr/reducer.ts
+++ b/src/store/bundlr/reducer.ts
@@ -52,9 +52,6 @@ export function bundlrReducer(state: BundlrState, action: Actions): BundlrState 
       const txId = action.payload.txId;
       return { ...state, txId };
 
-    case ActionType.SetIsUploading:
-      return { ...state, isUploading: action.payload.isUploading };
-
     case ActionType.SetPendingBalance:
       return { ...state, pendingBalance: action.payload.pendingBalance };
 


### PR DESCRIPTION
This PR

- Adds a `processArchCommsException`, which now handles exceptions during arch handshake.
From here we'll have a central point to communicate back to the user what their next steps may be if anything goes wrong with one of their selected archaeologists.

- Moves `incrementStage` out of the create sarco effect hook. Also adds an optional `forceIndex` param - currently being used to keep the exception indicator on the UI focused on the stage that originally generated it.

- Allows Bundlr `uploadFile` exceptions from `useBundlr` to bubble up to the handler in `useCreateSarchophagus`

- Updates `useSubmitTransaction` so it waits for the transaction to be confirmed (returns that promise, which is awaited in `executeStage`). 
This resolves the approve bug, and should resolve the premature create sarcophagus success declaration, although I didn't notice any noticeable difference in my tests.