### PR TITLE
Reload Archealogist List on a network change

### DIFF
--- a/src/store/embalm/actions.ts
+++ b/src/store/embalm/actions.ts
@@ -38,6 +38,7 @@ export enum ActionType {
   UpdateStepStatus = 'EMBALM_UPDATE_STEP_STATUS',
   SetArchaeologistException = 'EMBALM_SET_ARCHAEOLOGIST_EXCEPTION',
   ResetEmbalmState = 'EMBALM_RESET_EMBALM_STATE',
+  SetCurrentChainId = 'EMBALM_SET_CURRENT_CHAIN_ID',
 }
 
 export enum RecipientSetByOption {
@@ -102,6 +103,7 @@ type EmbalmPayload = {
   [ActionType.SetDiggingFeesFilter]: { filter: string };
   [ActionType.SetArchAddressSearch]: { search: string };
   [ActionType.ResetEmbalmState]: {};
+  [ActionType.SetCurrentChainId]: { chainId: number | undefined };
 };
 
 export function goToStep(step: Step): EmbalmActions {
@@ -356,6 +358,15 @@ export function enableSteps(): EmbalmActions {
   return {
     type: ActionType.EnableSteps,
     payload: {},
+  };
+}
+
+export function setCurrentChainId(chainId: number | undefined): EmbalmActions {
+  return {
+    type: ActionType.SetCurrentChainId,
+    payload: {
+      chainId,
+    },
   };
 }
 

--- a/src/store/embalm/reducer.ts
+++ b/src/store/embalm/reducer.ts
@@ -40,6 +40,7 @@ export interface EmbalmState {
   archAddressSearch: string;
   archaeologistEncryptedShards: ArchaeologistEncryptedShard[];
   areStepsDisabled: boolean;
+  currentChainId: number | undefined;
 }
 
 export const embalmInitialState: EmbalmState = {
@@ -66,6 +67,7 @@ export const embalmInitialState: EmbalmState = {
   archAddressSearch: '',
   archaeologistEncryptedShards: [],
   areStepsDisabled: false,
+  currentChainId: undefined,
 };
 
 function toggleStep(state: EmbalmState, step: Step): EmbalmState {
@@ -245,6 +247,9 @@ export function embalmReducer(state: EmbalmState, action: Actions): EmbalmState 
         value: action.payload.signature,
         updateSelected: true,
       });
+
+    case ActionType.SetCurrentChainId:
+      return { ...state, currentChainId: action.payload.chainId };
 
     case ActionType.DisableSteps:
       return { ...state, areStepsDisabled: true };


### PR DESCRIPTION
To test this be sure to change `useBootLibp2pNode(20_000);` to something longer than 20 seconds or the new arches will not be discovered. 

I couldn't really find something like `onNetworkSwitch` handler. So adding the check directly to the 'LoadArchealogist' seemed like the best move. 

See additional comment in code.