### PR TITLE
Sarco Modal

### DIFF
--- a/src/components/SarcoModal.tsx
+++ b/src/components/SarcoModal.tsx
@@ -20,7 +20,7 @@ interface ModalButtonProps {
 }
 
 interface SarcoModalProps {
-    children: JSX.Element[];
+    children: JSX.Element[] | JSX.Element;
     isDismissible: boolean;
     coverImage?: JSX.Element;
     title?: JSX.Element;

--- a/src/components/SarcoModal.tsx
+++ b/src/components/SarcoModal.tsx
@@ -22,37 +22,30 @@ interface ModalButtonProps {
 
 interface SarcoModalProps {
     isDismissible?: boolean;
-    image?: JSX.Element;
+    coverImage?: JSX.Element;
     title: string;
     subtitle?: string;
     primaryButton: ModalButtonProps,
     secondaryButton?: ModalButtonProps,
 }
 
-function useSarcoModal(props: SarcoModalProps) {
+function useSarcoModal() {
     const { isOpen, onOpen, onClose } = useDisclosure();
 
-    const {
-        title,
-        subtitle,
-        image,
-        primaryButton,
-        secondaryButton,
-        isDismissible = true,
-    } = props;
-
-    const modal = () =>
-        <Modal closeOnOverlayClick={isDismissible} isOpen={isOpen} onClose={onClose} isCentered>
+    const modal = (props: SarcoModalProps) =>
+        <Modal closeOnOverlayClick={props.isDismissible} isOpen={isOpen} onClose={onClose} isCentered>
             <ModalOverlay />
             <ModalContent minWidth='484px' paddingX='46px' paddingY='26px' bgColor={colors.brand[100]}>
 
-                {isDismissible && <Box height={5} />}
+                {props.isDismissible && <Box height={5} />}
+
+                {props.coverImage ?? <div />}
 
                 <ModalHeader paddingY={38} fontSize={'20px'} fontWeight={400} textAlign='center'>
-                    {title}
+                    {props.title}
                 </ModalHeader>
 
-                {isDismissible && <ModalCloseButton />}
+                {props.isDismissible && <ModalCloseButton />}
 
                 <ModalBody >
                     <Flex
@@ -64,24 +57,24 @@ function useSarcoModal(props: SarcoModalProps) {
                         alignContent='center'
                         bgGradient="linear(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.09) 100%)"
                     >
-                        <Text fontSize={'14px'} textAlign='center'>{subtitle ?? ''}</Text>
+                        <Text fontSize={'14px'} textAlign='center'>{props.subtitle ?? ''}</Text>
                         <Box height={30} />
                         <Button colorScheme='blue' onClick={() => {
-                            primaryButton.onClick();
-                            if (primaryButton.dismissesModal) onClose();
+                            props.primaryButton.onClick();
+                            if (props.primaryButton.dismissesModal) onClose();
                         }}>
-                            {primaryButton.label}
+                            {props.primaryButton.label}
                         </Button>
                     </Flex>
                 </ModalBody>
 
                 <ModalFooter>
-                    {secondaryButton &&
+                    {props.secondaryButton &&
                         <Button variant='ghost' onClick={() => {
-                            secondaryButton?.onClick();
-                            if (secondaryButton?.dismissesModal) onClose();
+                            props.secondaryButton?.onClick();
+                            if (props.secondaryButton?.dismissesModal) onClose();
                         }}>
-                            {secondaryButton.label}
+                            {props.secondaryButton.label}
                         </Button>}
                 </ModalFooter>
             </ModalContent>

--- a/src/components/SarcoModal.tsx
+++ b/src/components/SarcoModal.tsx
@@ -7,7 +7,6 @@ import {
     ModalBody,
     ModalCloseButton,
     Button,
-    Text,
     useDisclosure,
     Box,
     Flex,
@@ -21,11 +20,10 @@ interface ModalButtonProps {
 }
 
 interface SarcoModalProps {
-    isDismissible?: boolean;
+    children: JSX.Element[];
+    isDismissible: boolean;
     coverImage?: JSX.Element;
-    title: string;
-    subtitle?: string;
-    primaryButton: ModalButtonProps,
+    title?: JSX.Element;
     secondaryButton?: ModalButtonProps,
 }
 
@@ -37,14 +35,16 @@ function useSarcoModal() {
             <ModalOverlay />
             <ModalContent minWidth='484px' paddingX='46px' paddingY='26px' bgColor={colors.brand[100]}>
 
-                {props.isDismissible && <Box height={5} />}
+                {props.isDismissible ?? < Box height={5} />}
 
-                <ModalHeader paddingY={38} fontSize={'20px'} fontWeight={400} textAlign='center'>
-                    <Flex direction='column' alignItems={'center'}>
-                        {props.coverImage ?? <div />}
-                        {props.title}
-                    </Flex>
-                </ModalHeader>
+                {(!!props.title || !!props.coverImage) ?
+                    <ModalHeader paddingY={38}>
+                        <Flex direction='column' alignItems={'center'}>
+                            {props.coverImage}
+                            {props.title}
+                        </Flex>
+                    </ModalHeader> : <Box height={30} />
+                }
 
                 {props.isDismissible && <ModalCloseButton />}
 
@@ -58,14 +58,7 @@ function useSarcoModal() {
                         alignContent='center'
                         bgGradient="linear(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.09) 100%)"
                     >
-                        <Text fontSize={'14px'} textAlign='center'>{props.subtitle ?? ''}</Text>
-                        <Box height={30} />
-                        <Button onClick={() => {
-                            props.primaryButton.onClick();
-                            if (props.primaryButton.dismissesModal) onClose();
-                        }}>
-                            {props.primaryButton.label}
-                        </Button>
+                        {props.children}
                     </Flex>
                 </ModalBody>
 
@@ -81,7 +74,7 @@ function useSarcoModal() {
             </ModalContent>
         </Modal >;
 
-    return { SarcoModal: modal, openModal: onOpen };
+    return { SarcoModal: modal, openModal: onOpen, closeModal: onClose };
 }
 
 export { useSarcoModal };

--- a/src/components/SarcoModal.tsx
+++ b/src/components/SarcoModal.tsx
@@ -9,6 +9,8 @@ import {
     Button,
     Text,
     useDisclosure,
+    Box,
+    Flex,
 } from '@chakra-ui/react';
 import { colors } from 'theme/colors';
 
@@ -20,7 +22,7 @@ interface ModalButtonProps {
 
 interface SarcoModalProps {
     isDismissible?: boolean;
-    image?: string;
+    image?: JSX.Element;
     title: string;
     subtitle?: string;
     primaryButton: ModalButtonProps,
@@ -42,20 +44,38 @@ function useSarcoModal(props: SarcoModalProps) {
     const modal = () =>
         <Modal closeOnOverlayClick={isDismissible} isOpen={isOpen} onClose={onClose} isCentered>
             <ModalOverlay />
-            <ModalContent bgColor={colors.brand[100]}>
-                <ModalHeader>{title}</ModalHeader>
+            <ModalContent minWidth='484px' paddingX='46px' paddingY='26px' bgColor={colors.brand[100]}>
+
+                {isDismissible && <Box height={5} />}
+
+                <ModalHeader paddingY={38} fontSize={'20px'} fontWeight={400} textAlign='center'>
+                    {title}
+                </ModalHeader>
+
                 {isDismissible && <ModalCloseButton />}
-                <ModalBody>
-                    <Text>{subtitle ?? ''}</Text>
+
+                <ModalBody >
+                    <Flex
+                        direction='column'
+                        padding='32px'
+                        border='solid'
+                        borderColor={colors.brand[300]}
+                        borderWidth='1px'
+                        alignContent='center'
+                        bgGradient="linear(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.09) 100%)"
+                    >
+                        <Text fontSize={'14px'} textAlign='center'>{subtitle ?? ''}</Text>
+                        <Box height={30} />
+                        <Button colorScheme='blue' onClick={() => {
+                            primaryButton.onClick();
+                            if (primaryButton.dismissesModal) onClose();
+                        }}>
+                            {primaryButton.label}
+                        </Button>
+                    </Flex>
                 </ModalBody>
 
                 <ModalFooter>
-                    <Button colorScheme='blue' mr={3} onClick={() => {
-                        primaryButton.onClick();
-                        if (primaryButton.dismissesModal) onClose();
-                    }}>
-                        {primaryButton.label}
-                    </Button>
                     {secondaryButton &&
                         <Button variant='ghost' onClick={() => {
                             secondaryButton?.onClick();
@@ -65,7 +85,7 @@ function useSarcoModal(props: SarcoModalProps) {
                         </Button>}
                 </ModalFooter>
             </ModalContent>
-        </Modal>;
+        </Modal >;
 
     return { SarcoModal: modal, openModal: onOpen };
 }

--- a/src/components/SarcoModal.tsx
+++ b/src/components/SarcoModal.tsx
@@ -1,0 +1,73 @@
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalFooter,
+    ModalBody,
+    ModalCloseButton,
+    Button,
+    Text,
+    useDisclosure,
+} from '@chakra-ui/react';
+import { colors } from 'theme/colors';
+
+interface ModalButtonProps {
+    label: string;
+    onClick: () => void;
+    dismissesModal?: boolean;
+}
+
+interface SarcoModalProps {
+    isDismissible?: boolean;
+    image?: string;
+    title: string;
+    subtitle?: string;
+    primaryButton: ModalButtonProps,
+    secondaryButton?: ModalButtonProps,
+}
+
+function useSarcoModal(props: SarcoModalProps) {
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
+    const {
+        title,
+        subtitle,
+        image,
+        primaryButton,
+        secondaryButton,
+        isDismissible = true,
+    } = props;
+
+    const modal = () =>
+        <Modal closeOnOverlayClick={isDismissible} isOpen={isOpen} onClose={onClose} isCentered>
+            <ModalOverlay />
+            <ModalContent bgColor={colors.brand[100]}>
+                <ModalHeader>{title}</ModalHeader>
+                {isDismissible && <ModalCloseButton />}
+                <ModalBody>
+                    <Text>{subtitle ?? ''}</Text>
+                </ModalBody>
+
+                <ModalFooter>
+                    <Button colorScheme='blue' mr={3} onClick={() => {
+                        primaryButton.onClick();
+                        if (primaryButton.dismissesModal) onClose();
+                    }}>
+                        {primaryButton.label}
+                    </Button>
+                    {secondaryButton &&
+                        <Button variant='ghost' onClick={() => {
+                            secondaryButton?.onClick();
+                            if (secondaryButton?.dismissesModal) onClose();
+                        }}>
+                            {secondaryButton.label}
+                        </Button>}
+                </ModalFooter>
+            </ModalContent>
+        </Modal>;
+
+    return { SarcoModal: modal, openModal: onOpen };
+}
+
+export { useSarcoModal };

--- a/src/components/SarcoModal.tsx
+++ b/src/components/SarcoModal.tsx
@@ -39,10 +39,11 @@ function useSarcoModal() {
 
                 {props.isDismissible && <Box height={5} />}
 
-                {props.coverImage ?? <div />}
-
                 <ModalHeader paddingY={38} fontSize={'20px'} fontWeight={400} textAlign='center'>
-                    {props.title}
+                    <Flex direction='column' alignItems={'center'}>
+                        {props.coverImage ?? <div />}
+                        {props.title}
+                    </Flex>
                 </ModalHeader>
 
                 {props.isDismissible && <ModalCloseButton />}
@@ -59,7 +60,7 @@ function useSarcoModal() {
                     >
                         <Text fontSize={'14px'} textAlign='center'>{props.subtitle ?? ''}</Text>
                         <Box height={30} />
-                        <Button colorScheme='blue' onClick={() => {
+                        <Button onClick={() => {
                             props.primaryButton.onClick();
                             if (props.primaryButton.dismissesModal) onClose();
                         }}>
@@ -68,7 +69,7 @@ function useSarcoModal() {
                     </Flex>
                 </ModalBody>
 
-                <ModalFooter>
+                <ModalFooter alignSelf={'center'}>
                     {props.secondaryButton &&
                         <Button variant='ghost' onClick={() => {
                             props.secondaryButton?.onClick();

--- a/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
+++ b/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
@@ -1,9 +1,13 @@
 import { Box, Flex, Text, VStack } from '@chakra-ui/react';
+import { useSarcoModal } from 'components/SarcoModal';
 import { ReviewSarcophagusTable } from './ReviewSarcophagusTable';
 import { SarcophagusSummaryFees } from './SarcophagusSummaryFees';
 import { SummaryErrorIcon } from './SummaryErrorIcon';
 
 export function ReviewSarcophagus() {
+
+  const { SarcoModal, openModal } = useSarcoModal();
+
   return (
     <VStack
       align="left"
@@ -35,6 +39,7 @@ export function ReviewSarcophagus() {
         <ReviewSarcophagusTable />
         <SarcophagusSummaryFees />
         <Flex
+          onClick={openModal}
           mt={3}
           alignItems="center"
         >
@@ -42,10 +47,18 @@ export function ReviewSarcophagus() {
           <Text
             ml={2}
             color="brand.500"
+            textAlign={'center'}
           >
             = missing information
           </Text>
         </Flex>
+        <SarcoModal
+          coverImage={<Flex height={300} width={300} bgColor={'#777'} mb={10} />}
+          title='Download PDF'
+          subtitle='Download and send this to your recipient. Do not store this online or let anyone see.'
+          primaryButton={{ label: 'Download', onClick: () => { }, dismissesModal: true }}
+          secondaryButton={{ label: 'Close', onClick: () => { }, dismissesModal: true }}
+        />
       </Flex>
     </VStack>
   );

--- a/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
+++ b/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text, VStack } from '@chakra-ui/react';
+import { Box, Button, Flex, Text, VStack } from '@chakra-ui/react';
 import { useSarcoModal } from 'components/SarcoModal';
 import { ReviewSarcophagusTable } from './ReviewSarcophagusTable';
 import { SarcophagusSummaryFees } from './SarcophagusSummaryFees';
@@ -6,7 +6,7 @@ import { SummaryErrorIcon } from './SummaryErrorIcon';
 
 export function ReviewSarcophagus() {
 
-  const { SarcoModal, openModal } = useSarcoModal();
+  const { SarcoModal, openModal, closeModal } = useSarcoModal();
 
   return (
     <VStack
@@ -53,12 +53,17 @@ export function ReviewSarcophagus() {
           </Text>
         </Flex>
         <SarcoModal
+          isDismissible={false}
           coverImage={<Flex height={300} width={300} bgColor={'#777'} mb={10} />}
-          title='Download PDF'
-          subtitle='Download and send this to your recipient. Do not store this online or let anyone see.'
-          primaryButton={{ label: 'Download', onClick: () => { }, dismissesModal: true }}
+          title={<Text fontSize={'20px'} fontWeight={400} textAlign='center'>Download PDF</Text>}
           secondaryButton={{ label: 'Close', onClick: () => { }, dismissesModal: true }}
-        />
+        >
+          <Text fontSize={'14px'} textAlign='center'>Download and send this to your recipient. Do not store this online or let anyone see.</Text>
+          <Box height={30} />
+          <Button onClick={() => closeModal()}>
+            Download
+          </Button>
+        </SarcoModal>
       </Flex>
     </VStack>
   );

--- a/src/theme/components/Button.ts
+++ b/src/theme/components/Button.ts
@@ -16,6 +16,9 @@ export const Button = {
     ghost: {
       fontWeight: 400,
       fontSize: 14,
+      _hover: {
+        bg: 'brand.200',
+      },
     },
     link: {
       color: 'brand.950',


### PR DESCRIPTION
This PR adds a re-usable `SarcoModal` component, exposed via the `useSarcoModal` hook, along with helper methods for consuming the modal.

Screenshot:
<img width="1520" alt="Screenshot 2022-11-02 at 17 16 22" src="https://user-images.githubusercontent.com/7101382/199557196-433b6b85-4204-418e-8273-02f3607c7495.png">

TESTING:

- Click the `Create` step in the create sarco steps on the left.
- Click on the `missing information` indicator at the bottom of the summary list. A dummy modal should pop up.


## TODO (important): 
A single commit, `06a7cab0dd1a10976c85d0b70dbb2f95fbeab1c0` can be reverted via git to remove this demo functionality. Added this commit as a sort of copy-paste doc on modal's usage, so can be reverted once we have actual in-app usage.

