### PR TITLE
Fix decryption bug

### DIFF
--- a/src/features/resurrection/hooks/useResurrection.ts
+++ b/src/features/resurrection/hooks/useResurrection.ts
@@ -59,8 +59,9 @@ export function useResurrection(sarcoId: string, recipientPrivateKey: string) {
       // Convert the shards from their hex strings to Uint8Array
       const unencryptedShards = archaeologists
         .map(a => {
-          if (arrayify(a.unencryptedShard).length > 0) {
-            return Buffer.from(arrayify(a.unencryptedShard));
+          const arrayifiedShard = arrayify(a.unencryptedShard);
+          if (arrayifiedShard.length > 0) {
+            return Buffer.from(arrayifiedShard);
           }
         })
         .filter(a => a);


### PR DESCRIPTION
There was a decryption bug on claim where the SSS `combine` function would try to use the shards from the archaeologists that failed to unwrap, causing the `combine` function to fail.