### PR TITLE
Retry updates

### DIFF
--- a/src/features/embalm/stepContent/components/ProgressTrackerStage.tsx
+++ b/src/features/embalm/stepContent/components/ProgressTrackerStage.tsx
@@ -57,6 +57,7 @@ export function ProgressTrackerStage({
               variant="outline"
               py="11px"
               px="13px"
+              mr="15px"
               onClick={retryStage}
             >
               Retry

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useArchaeologistSignatureNegotiation.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useArchaeologistSignatureNegotiation.ts
@@ -48,8 +48,6 @@ export function useArchaeologistSignatureNegotiation() {
     }
   }
 
-  const archaeologistConnections = selectedArchaeologists.map(a => a.connection);
-
   const initiateSarcophagusNegotiation = useCallback(async (): Promise<void> => {
     console.log('starting the negotiation');
     const lowestRewrapInterval = getLowestRewrapInterval(selectedArchaeologists);
@@ -62,7 +60,6 @@ export function useArchaeologistSignatureNegotiation() {
     await Promise.all(
       selectedArchaeologists.map(async arch => {
         if (!arch.connection) {
-          console.log(archaeologistConnections);
           console.log(`${arch.profile.peerId} connection is undefined`);
           setArchaeologistException(arch.profile.peerId, {
             code: ArchaeologistExceptionCode.CONNECTION_EXCEPTION,
@@ -140,7 +137,6 @@ export function useArchaeologistSignatureNegotiation() {
   }, [
     dispatch,
     selectedArchaeologists,
-    archaeologistConnections,
     archaeologistShards,
     encryptedShardsTxId,
     dialSelectedArchaeologists,

--- a/src/hooks/libp2p/useLibp2p.ts
+++ b/src/hooks/libp2p/useLibp2p.ts
@@ -55,7 +55,7 @@ export function useLibp2p() {
   const onPeerConnect = useCallback(
     (evt: CustomEvent<Connection>) => {
       const peerId = evt.detail.remotePeer.toString();
-      dispatch(setArchaeologistConnection(peerId, evt.detail));
+      setTimeout(() => dispatch(setArchaeologistConnection(peerId, evt.detail)), 500);
     },
     [dispatch]
   );


### PR DESCRIPTION
Biggest change in this PR is a margin added to the right side of the retry button.

The retry mechanism seems to work pretty well. 

There is one tiny edge case at the archaeologist signature step where the retry couldn't work if the problem was a lost connection to the arch node. This should be extremely rare in practice -- an arch node going offline would likely not come back on for quite a bit, and we should be handling that problem a different way anyway, ie, having informing the user and having them re-select.

I've tried to account for this edge case by calling `dialSelectedArchaeologists`, which *does* re-connect to the problem arch if they're back online (again, unlikely for such a short period), but the button will have to clicked twice -- first to fail and re-dial, and second to actually re-attempt `initiateSarcophagusNegotiation`. 

Spent some time trying to get this down to a single click without doing some major refactors but decided it wasn't worth it in the end. The re-select-archaeologist-because-one-of-your-selected-is-dead UX is far more important IMO.

