### PR TITLE
Decouple public key

### DIFF
--- a/src/components/MagicFormFiller.tsx
+++ b/src/components/MagicFormFiller.tsx
@@ -10,6 +10,7 @@ import {
   setFile,
   setName,
   setRecipientState,
+  setRequiredArchaeologists,
   setResurrection,
   setResurrectionRadioValue,
 } from 'store/embalm/actions';
@@ -79,6 +80,11 @@ export function MagicFormFiller() {
     dispatch(goToStep(Step.SelectArchaeologists));
     await sleep(delay);
     dispatch(selectArchaeologist(onlineArchaeologists[0]));
+    dispatch(goToStep(Step.SelectArchaeologists));
+
+    // Set required archaeologists
+    await sleep(delay);
+    dispatch(setRequiredArchaeologists(1));
 
     // Create sarcophagus
     await sleep(delay);

--- a/src/features/embalm/stepContent/components/ProgressTrackerStage.tsx
+++ b/src/features/embalm/stepContent/components/ProgressTrackerStage.tsx
@@ -57,6 +57,7 @@ export function ProgressTrackerStage({
               variant="outline"
               py="11px"
               px="13px"
+              mr="15px"
               onClick={retryStage}
             >
               Retry

--- a/src/features/embalm/stepContent/context/CreateSarcophagusContext.tsx
+++ b/src/features/embalm/stepContent/context/CreateSarcophagusContext.tsx
@@ -1,12 +1,10 @@
 import React, { createContext, ReactNode, useEffect, useState } from 'react';
 import { createEncryptionKeypairAsync } from '../hooks/useCreateEncryptionKeypair';
-import { useSelector } from '../../../../store';
 import { ArchaeologistEncryptedShard } from '../../../../types';
 
 interface CreateSarcophagusContextProps {
   outerPrivateKey: string;
   outerPublicKey: string;
-  publicKeysReady: boolean;
   archaeologistShards: ArchaeologistEncryptedShard[];
   setArchaeologistShards: React.Dispatch<React.SetStateAction<ArchaeologistEncryptedShard[]>>;
   encryptedShardsTxId: string;
@@ -17,7 +15,6 @@ interface CreateSarcophagusContextProps {
   setArchaeologistSignatures: React.Dispatch<React.SetStateAction<Map<string, string>>>;
   sarcophagusPayloadTxId: string;
   setSarcophagusPayloadTxId: React.Dispatch<React.SetStateAction<string>>;
-  setPublicKeysReady: React.Dispatch<React.SetStateAction<boolean>>;
   setOuterPrivateKey: React.Dispatch<React.SetStateAction<string>>;
   setOuterPublicKey: React.Dispatch<React.SetStateAction<string>>;
   sarcophagusTxId: string;
@@ -25,7 +22,6 @@ interface CreateSarcophagusContextProps {
 }
 
 const initialCreateSarcophagusState = {
-  publicKeysReady: false,
   outerPrivateKey: '',
   outerPublicKey: '',
   archaeologistShards: [] as ArchaeologistEncryptedShard[],
@@ -38,20 +34,8 @@ const initialCreateSarcophagusState = {
 
 const CreateSarcophagusContext = createContext({} as CreateSarcophagusContextProps);
 
+// Global state from embalm steps, used to create sarcophagus
 function CreateSarcophagusContextProvider({ children }: { children: ReactNode }) {
-  // Global state from embalm steps, used to create sarcophagus
-  const { selectedArchaeologists } = useSelector(x => x.embalmState);
-  const [publicKeysReady, setPublicKeysReady] = useState(
-    initialCreateSarcophagusState.publicKeysReady
-  );
-
-  // Sets publicKeysReady to true once all archaeologists have sent their keys
-  useEffect(() => {
-    if (selectedArchaeologists.length > 0) {
-      setPublicKeysReady(selectedArchaeologists.every(arch => !!arch.publicKey));
-    }
-  }, [selectedArchaeologists]);
-
   // Generate the outer layer keypair for the sarcophagus.
   const [outerPrivateKey, setOuterPrivateKey] = useState(
     initialCreateSarcophagusState.outerPrivateKey
@@ -95,7 +79,6 @@ function CreateSarcophagusContextProvider({ children }: { children: ReactNode })
       value={{
         outerPrivateKey,
         outerPublicKey,
-        publicKeysReady,
         archaeologistShards,
         setArchaeologistShards,
         encryptedShardsTxId,
@@ -106,7 +89,6 @@ function CreateSarcophagusContextProvider({ children }: { children: ReactNode })
         setArchaeologistSignatures,
         sarcophagusPayloadTxId,
         setSarcophagusPayloadTxId,
-        setPublicKeysReady,
         setOuterPrivateKey,
         setOuterPublicKey,
         sarcophagusTxId,

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useArchaeologistSignatureNegotiation.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useArchaeologistSignatureNegotiation.ts
@@ -27,7 +27,7 @@ export function useArchaeologistSignatureNegotiation() {
     setNegotiationTimestamp,
   } = useContext(CreateSarcophagusContext);
 
-  const { dialSelectedArchaeologists } = useDialArchaeologists();
+  const { dialArchaeologist } = useDialArchaeologists();
 
   function processDeclinedSignatureCode(
     code: SarcophagusValidationError,
@@ -48,7 +48,7 @@ export function useArchaeologistSignatureNegotiation() {
     }
   }
 
-  const initiateSarcophagusNegotiation = useCallback(async (): Promise<void> => {
+  const initiateSarcophagusNegotiation = useCallback(async (isRetry: boolean): Promise<void> => {
     console.log('starting the negotiation');
     const lowestRewrapInterval = getLowestRewrapInterval(selectedArchaeologists);
 
@@ -66,11 +66,12 @@ export function useArchaeologistSignatureNegotiation() {
             message: 'No connection to archaeologist',
           });
 
-          if (arch.fullPeerId) {
-            await dialSelectedArchaeologists();
+          if (isRetry && arch.fullPeerId) {
+            arch.connection = await dialArchaeologist(arch.fullPeerId);
+            if (!arch.connection) return;
+          } else {
+            return;
           }
-
-          return;
         }
 
         const negotiationParams: ArchaeologistSignatureNegotiationParams = {
@@ -139,7 +140,7 @@ export function useArchaeologistSignatureNegotiation() {
     selectedArchaeologists,
     archaeologistShards,
     encryptedShardsTxId,
-    dialSelectedArchaeologists,
+    dialArchaeologist,
     setArchaeologistSignatures,
     setNegotiationTimestamp,
   ]);

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useArchaeologistSignatureNegotiation.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useArchaeologistSignatureNegotiation.ts
@@ -48,8 +48,6 @@ export function useArchaeologistSignatureNegotiation() {
     }
   }
 
-  const archaeologistConnections = selectedArchaeologists.map(a => a.connection);
-
   const initiateSarcophagusNegotiation = useCallback(async (): Promise<void> => {
     console.log('starting the negotiation');
     const lowestRewrapInterval = getLowestRewrapInterval(selectedArchaeologists);
@@ -62,7 +60,6 @@ export function useArchaeologistSignatureNegotiation() {
     await Promise.all(
       selectedArchaeologists.map(async arch => {
         if (!arch.connection) {
-          console.log(archaeologistConnections);
           console.log(`${arch.profile.peerId} connection is undefined`);
           setArchaeologistException(arch.profile.peerId, {
             code: ArchaeologistExceptionCode.CONNECTION_EXCEPTION,
@@ -140,7 +137,6 @@ export function useArchaeologistSignatureNegotiation() {
   }, [
     dispatch,
     selectedArchaeologists,
-    archaeologistConnections,
     archaeologistShards,
     encryptedShardsTxId,
     dialSelectedArchaeologists,

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useClearSarcophagusState.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useClearSarcophagusState.ts
@@ -15,7 +15,6 @@ export interface SuccessData {
 
 export function useClearSarcophagusState() {
   const {
-    setPublicKeysReady,
     setOuterPrivateKey,
     setOuterPublicKey,
     setArchaeologistShards,
@@ -41,7 +40,6 @@ export function useClearSarcophagusState() {
     setSuccessSarcophagusTxId(sarcophagusTxId);
 
     // reset state local to create sarcophagus
-    setPublicKeysReady(initialCreateSarcophagusState.publicKeysReady);
     setOuterPrivateKey(initialCreateSarcophagusState.outerPrivateKey);
     setOuterPublicKey(initialCreateSarcophagusState.outerPublicKey);
     setArchaeologistShards(initialCreateSarcophagusState.archaeologistShards);
@@ -57,7 +55,6 @@ export function useClearSarcophagusState() {
     encryptedShardsTxId,
     sarcophagusPayloadTxId,
     sarcophagusTxId,
-    setPublicKeysReady,
     setOuterPrivateKey,
     setOuterPublicKey,
     setArchaeologistShards,

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useCreateSarcophagus.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useCreateSarcophagus.ts
@@ -11,6 +11,7 @@ import { useUploadDoubleEncryptedFile } from './useUploadDoubleEncryptedFile';
 import { useApproveSarcoToken } from './useApproveSarcoToken';
 import { useSubmitSarcophagus } from './useSubmitSarcophagus';
 import { useClearSarcophagusState } from './useClearSarcophagusState';
+import { useRequestPublicKeys } from './useRequestPublicKeys';
 
 export function useCreateSarcophagus(
   createSarcophagusStages: Record<number, string>,
@@ -30,6 +31,7 @@ export function useCreateSarcophagus(
 
   // Each hook represents a stage in the create sarcophagus process
   const { dialSelectedArchaeologists } = useDialArchaeologists();
+  const { requestPublicKeys } = useRequestPublicKeys();
   const { uploadAndSetEncryptedShards } = useUploadEncryptedShards();
   const { initiateSarcophagusNegotiation } = useArchaeologistSignatureNegotiation();
   const { uploadAndSetDoubleEncryptedFile } = useUploadDoubleEncryptedFile();
@@ -40,6 +42,7 @@ export function useCreateSarcophagus(
   const stagesMap = useMemo(() => {
     return new Map<CreateSarcophagusStage, (...args: any[]) => Promise<any>>([
       [CreateSarcophagusStage.DIAL_ARCHAEOLOGISTS, dialSelectedArchaeologists],
+      [CreateSarcophagusStage.GET_PUBLIC_KEYS, requestPublicKeys],
       [CreateSarcophagusStage.UPLOAD_ENCRYPTED_SHARDS, uploadAndSetEncryptedShards],
       [CreateSarcophagusStage.ARCHAEOLOGIST_NEGOTIATION, initiateSarcophagusNegotiation],
       [CreateSarcophagusStage.UPLOAD_PAYLOAD, uploadAndSetDoubleEncryptedFile],
@@ -50,6 +53,7 @@ export function useCreateSarcophagus(
     ]);
   }, [
     dialSelectedArchaeologists,
+    requestPublicKeys,
     uploadAndSetEncryptedShards,
     initiateSarcophagusNegotiation,
     uploadAndSetDoubleEncryptedFile,

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useCreateSarcophagus.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useCreateSarcophagus.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from '../../../../../store';
 import { disableSteps } from 'store/embalm/actions';
 import { useArchaeologistSignatureNegotiation } from 'features/embalm/stepContent/hooks/useCreateSarcophagus/useArchaeologistSignatureNegotiation';
@@ -10,7 +10,6 @@ import { useUploadEncryptedShards } from './useUploadEncryptedShards';
 import { useUploadDoubleEncryptedFile } from './useUploadDoubleEncryptedFile';
 import { useApproveSarcoToken } from './useApproveSarcoToken';
 import { useSubmitSarcophagus } from './useSubmitSarcophagus';
-import { CreateSarcophagusContext } from '../../context/CreateSarcophagusContext';
 import { useClearSarcophagusState } from './useClearSarcophagusState';
 
 export function useCreateSarcophagus(
@@ -27,7 +26,6 @@ export function useCreateSarcophagus(
   const [stageError, setStageError] = useState<string>();
 
   // Returns true when all public keys have been received from archaoelogists
-  const { publicKeysReady } = useContext(CreateSarcophagusContext);
 
   // Each hook represents a stage in the create sarcophagus process
   const { dialSelectedArchaeologists } = useDialArchaeologists();
@@ -89,10 +87,6 @@ export function useCreateSarcophagus(
 
       if (!stageExecuting && !stageError && currentStage !== CreateSarcophagusStage.COMPLETED) {
         try {
-          if (currentStage === CreateSarcophagusStage.UPLOAD_ENCRYPTED_SHARDS && !publicKeysReady) {
-            return;
-          }
-
           const currentStageFunction = stagesMap.get(currentStage);
           if (currentStageFunction) {
             await executeStage(currentStageFunction);
@@ -114,7 +108,6 @@ export function useCreateSarcophagus(
     stagesMap,
     stageError,
     dispatch,
-    publicKeysReady,
     createSarcophagusStages,
     selectedArchaeologists,
   ]);

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useDialArchaeologists.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useDialArchaeologists.ts
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import { setArchaeologistConnection, setArchaeologistException } from 'store/embalm/actions';
 import { useDispatch, useSelector } from '../../../../../store';
 import { ArchaeologistExceptionCode } from 'types';
-import { useLibp2p } from '../../../../../hooks/libp2p/useLibp2p';
 import { CreateSarcophagusStage } from '../../utils/createSarcophagus';
 import { createSarcophagusErrors } from '../../utils/errors';
 import { PeerId } from '@libp2p/interface-peer-id';
@@ -11,12 +10,9 @@ export function useDialArchaeologists() {
   const dispatch = useDispatch();
   const { selectedArchaeologists } = useSelector(s => s.embalmState);
 
-  const { resetPublicKeyStream } = useLibp2p();
   const libp2pNode = useSelector(s => s.appState.libp2pNode);
 
   const dialSelectedArchaeologists = useCallback(async () => {
-    await resetPublicKeyStream();
-
     const dialFailedArchaeologists = [];
     for await (const arch of selectedArchaeologists) {
       try {
@@ -37,7 +33,7 @@ export function useDialArchaeologists() {
     if (dialFailedArchaeologists.length) {
       throw Error(createSarcophagusErrors[CreateSarcophagusStage.DIAL_ARCHAEOLOGISTS]);
     }
-  }, [selectedArchaeologists, libp2pNode, dispatch, resetPublicKeyStream]);
+  }, [selectedArchaeologists, libp2pNode, dispatch]);
 
   const pingArchaeologist = useCallback(
     async (peerId: PeerId, onComplete: Function) => {

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useDialArchaeologists.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useDialArchaeologists.ts
@@ -12,6 +12,22 @@ export function useDialArchaeologists() {
 
   const libp2pNode = useSelector(s => s.appState.libp2pNode);
 
+  const dialArchaeologist = useCallback(async (peerId: PeerId) => {
+    try {
+      const connection = await libp2pNode?.dial(peerId);
+      if (!connection) throw Error('No connection obtained from dial');
+      dispatch(setArchaeologistConnection(peerId.toString(), connection));
+      return connection;
+    } catch (e) {
+      dispatch(
+        setArchaeologistException(peerId.toString(), {
+          code: ArchaeologistExceptionCode.CONNECTION_EXCEPTION,
+          message: 'Could not establish a connection',
+        })
+      );
+    }
+  }, [libp2pNode, dispatch]);
+
   const dialSelectedArchaeologists = useCallback(async () => {
     const dialFailedArchaeologists = [];
     for await (const arch of selectedArchaeologists) {
@@ -68,5 +84,6 @@ export function useDialArchaeologists() {
   return {
     dialSelectedArchaeologists,
     pingArchaeologist,
+    dialArchaeologist,
   };
 }

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useRequestPublicKeys.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useRequestPublicKeys.ts
@@ -4,6 +4,7 @@ import { useDispatch } from 'store/index';
 import { setArchaeologistException, setArchaeologistPublicKey } from 'store/embalm/actions';
 import { Archaeologist, ArchaeologistExceptionCode } from 'types';
 import { useCallback } from 'react';
+import { ethers } from 'ethers';
 
 interface PublicKeyResponseFromArchaeologist {
   signature: string;
@@ -17,39 +18,77 @@ export function useRequestPublicKeys() {
     async (selectedArchaeologists: Archaeologist[]) => {
       const archPublicKeys: string[] = [];
       for await (const arch of selectedArchaeologists) {
-        const stream = await arch.connection!.newStream(PUBLIC_KEY_STREAM);
-        await pipe([new Uint8Array(0)], stream, async source => {
-          for await (const data of source) {
-            try {
-              const decoded = new TextDecoder().decode(data.subarray());
-              console.log(`received public key ${decoded}`);
+        if (!arch.connection) {
+          dispatch(
+            setArchaeologistException(arch.profile.peerId, {
+              code: ArchaeologistExceptionCode.CONNECTION_EXCEPTION,
+              message: 'No connection to archaeologist',
+            })
+          );
+          continue;
+        }
 
-              const publicKeyResponse: PublicKeyResponseFromArchaeologist = JSON.parse(decoded);
-              archPublicKeys.push(publicKeyResponse.encryptionPublicKey);
-              dispatch(
-                setArchaeologistPublicKey(
-                  arch.profile.peerId,
-                  publicKeyResponse.encryptionPublicKey
-                )
-              );
-            } catch (e) {
-              console.error(e);
+        const handleException = (e: any) => {
+          // TODO: `message` will (likely) be user-facing. Need friendlier verbiage.
+          const message = `Exception occurred in public key request stream for: ${arch.profile.archAddress}`;
+          console.error(message, e);
+          dispatch(
+            setArchaeologistException(arch.profile.peerId, {
+              code: ArchaeologistExceptionCode.STREAM_EXCEPTION,
+              message,
+            })
+          );
+        };
+
+        try {
+          const stream = await arch.connection.newStream(PUBLIC_KEY_STREAM);
+          await pipe([new Uint8Array(0)], stream, async source => {
+            for await (const data of source) {
+              try {
+                const decoded = new TextDecoder().decode(data.subarray());
+                console.log(`received public key ${decoded}`);
+
+                const publicKeyResponse: PublicKeyResponseFromArchaeologist = JSON.parse(decoded);
+                const signerAddress = ethers.utils.verifyMessage(
+                  publicKeyResponse.encryptionPublicKey,
+                  publicKeyResponse.signature
+                );
+
+                if (signerAddress !== arch.profile.archAddress) {
+                  const message = 'Signature does not match Archaeologist address';
+                  console.error(message);
+                  dispatch(
+                    setArchaeologistException(arch.profile.peerId, {
+                      code: ArchaeologistExceptionCode.STREAM_EXCEPTION,
+                      message,
+                    })
+                  );
+                  continue;
+                }
+
+                archPublicKeys.push(publicKeyResponse.encryptionPublicKey);
+                dispatch(
+                  setArchaeologistPublicKey(
+                    arch.profile.peerId,
+                    publicKeyResponse.encryptionPublicKey
+                  )
+                );
+              } catch (e) {
+                console.error(e);
+                dispatch(
+                  setArchaeologistException(arch.profile.peerId, {
+                    code: ArchaeologistExceptionCode.STREAM_EXCEPTION,
+                    message: 'Something went wrong during public key request',
+                  })
+                );
+              }
             }
-          }
-        })
-          .catch(e => {
-            // TODO: `message` will (likely) be user-facing. Need friendlier verbiage.
-            const message = `Exception occurred in negotiation stream for: ${arch.profile.archAddress}`;
-            console.error(`Stream exception on ${arch.profile.peerId}`, e);
-            dispatch(
-              setArchaeologistException(arch.profile.peerId, {
-                code: ArchaeologistExceptionCode.STREAM_EXCEPTION,
-                message,
-              })
-            );
-            throw Error('stream exception');
           })
-          .finally(() => stream.close());
+            .catch(handleException)
+            .finally(() => stream.close());
+        } catch (e) {
+          handleException(e);
+        }
       }
 
       return archPublicKeys;

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useRequestPublicKeys.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useRequestPublicKeys.ts
@@ -1,8 +1,8 @@
 import { pipe } from 'it-pipe';
 import { PUBLIC_KEY_STREAM } from 'lib/config/node_config';
-import { useDispatch } from 'store/index';
+import { useDispatch, useSelector } from 'store/index';
 import { setArchaeologistException, setArchaeologistPublicKey } from 'store/embalm/actions';
-import { Archaeologist, ArchaeologistExceptionCode } from 'types';
+import { ArchaeologistExceptionCode } from 'types';
 import { useCallback } from 'react';
 import { ethers } from 'ethers';
 import { useDialArchaeologists } from './useDialArchaeologists';
@@ -15,9 +15,10 @@ interface PublicKeyResponseFromArchaeologist {
 export function useRequestPublicKeys() {
   const dispatch = useDispatch();
   const { dialArchaeologist } = useDialArchaeologists();
+  const { selectedArchaeologists } = useSelector(x => x.embalmState);
 
   const requestPublicKeys = useCallback(
-    async (selectedArchaeologists: Archaeologist[], isRetry: boolean) => {
+    async (isRetry: boolean) => {
       const archPublicKeys: string[] = [];
       for await (const arch of selectedArchaeologists) {
         if (!arch.connection) {
@@ -99,9 +100,11 @@ export function useRequestPublicKeys() {
         }
       }
 
-      return archPublicKeys;
+      if (archPublicKeys.length < selectedArchaeologists.length) {
+        throw new Error('Not enough public keys');
+      }
     },
-    [dispatch, dialArchaeologist]
+    [dispatch, dialArchaeologist, selectedArchaeologists]
   );
 
   return {

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useRequestPublicKeys.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useRequestPublicKeys.ts
@@ -1,0 +1,63 @@
+import { pipe } from 'it-pipe';
+import { PUBLIC_KEY_STREAM } from 'lib/config/node_config';
+import { useDispatch } from 'store/index';
+import { setArchaeologistException, setArchaeologistPublicKey } from 'store/embalm/actions';
+import { Archaeologist, ArchaeologistExceptionCode } from 'types';
+import { useCallback } from 'react';
+
+interface PublicKeyResponseFromArchaeologist {
+  signature: string;
+  encryptionPublicKey: string;
+}
+
+export function useRequestPublicKeys() {
+  const dispatch = useDispatch();
+
+  const requestPublicKeys = useCallback(
+    async (selectedArchaeologists: Archaeologist[]) => {
+      const archPublicKeys: string[] = [];
+      for await (const arch of selectedArchaeologists) {
+        const stream = await arch.connection!.newStream(PUBLIC_KEY_STREAM);
+        await pipe([new Uint8Array(0)], stream, async source => {
+          for await (const data of source) {
+            try {
+              const decoded = new TextDecoder().decode(data.subarray());
+              console.log(`received public key ${decoded}`);
+
+              const publicKeyResponse: PublicKeyResponseFromArchaeologist = JSON.parse(decoded);
+              archPublicKeys.push(publicKeyResponse.encryptionPublicKey);
+              dispatch(
+                setArchaeologistPublicKey(
+                  arch.profile.peerId,
+                  publicKeyResponse.encryptionPublicKey
+                )
+              );
+            } catch (e) {
+              console.error(e);
+            }
+          }
+        })
+          .catch(e => {
+            // TODO: `message` will (likely) be user-facing. Need friendlier verbiage.
+            const message = `Exception occurred in negotiation stream for: ${arch.profile.archAddress}`;
+            console.error(`Stream exception on ${arch.profile.peerId}`, e);
+            dispatch(
+              setArchaeologistException(arch.profile.peerId, {
+                code: ArchaeologistExceptionCode.STREAM_EXCEPTION,
+                message,
+              })
+            );
+            throw Error('stream exception');
+          })
+          .finally(() => stream.close());
+      }
+
+      return archPublicKeys;
+    },
+    [dispatch]
+  );
+
+  return {
+    requestPublicKeys,
+  };
+}

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadEncryptedShards.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadEncryptedShards.ts
@@ -4,6 +4,7 @@ import { encryptShards } from '../../utils/createSarcophagus';
 import useArweaveService from '../../../../../hooks/useArweaveService';
 import { useSelector } from '../../../../../store';
 import { CreateSarcophagusContext } from '../../context/CreateSarcophagusContext';
+import { useRequestPublicKeys } from './useRequestPublicKeys';
 
 export function useUploadEncryptedShards() {
   const { selectedArchaeologists, requiredArchaeologists } = useSelector(x => x.embalmState);
@@ -11,6 +12,7 @@ export function useUploadEncryptedShards() {
     useContext(CreateSarcophagusContext);
 
   const { uploadToArweave } = useArweaveService();
+  const { requestPublicKeys } = useRequestPublicKeys();
 
   const uploadAndSetEncryptedShards = useCallback(async () => {
     try {
@@ -22,7 +24,7 @@ export function useUploadEncryptedShards() {
 
       // Step 2: Encrypt each shard of the outer layer private key using each archaeologist's public
       // key
-      const archPublicKeys = selectedArchaeologists.map(x => x.publicKey!);
+      const archPublicKeys = await requestPublicKeys(selectedArchaeologists);
       const encShards = await encryptShards(archPublicKeys, shards);
 
       // Step 3: Create a mapping of arch public keys -> encrypted shards; upload to arweave
@@ -45,6 +47,7 @@ export function useUploadEncryptedShards() {
     requiredArchaeologists,
     outerPrivateKey,
     selectedArchaeologists,
+    requestPublicKeys,
     uploadToArweave,
     setArchaeologistShards,
     setEncryptedShardsTxId,

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadEncryptedShards.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadEncryptedShards.ts
@@ -14,7 +14,7 @@ export function useUploadEncryptedShards() {
   const { uploadToArweave } = useArweaveService();
   const { requestPublicKeys } = useRequestPublicKeys();
 
-  const uploadAndSetEncryptedShards = useCallback(async () => {
+  const uploadAndSetEncryptedShards = useCallback(async (isRetry: boolean) => {
     try {
       // Step 1: Split the outer layer private key using shamirs secret sharing
       const shards: Uint8Array[] = split(outerPrivateKey, {
@@ -24,7 +24,7 @@ export function useUploadEncryptedShards() {
 
       // Step 2: Encrypt each shard of the outer layer private key using each archaeologist's public
       // key
-      const archPublicKeys = await requestPublicKeys(selectedArchaeologists);
+      const archPublicKeys = await requestPublicKeys(selectedArchaeologists, isRetry);
 
       if (archPublicKeys.length < selectedArchaeologists.length) {
         throw new Error('Not enough public keys');

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadEncryptedShards.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadEncryptedShards.ts
@@ -4,7 +4,6 @@ import { encryptShards } from '../../utils/createSarcophagus';
 import useArweaveService from '../../../../../hooks/useArweaveService';
 import { useSelector } from '../../../../../store';
 import { CreateSarcophagusContext } from '../../context/CreateSarcophagusContext';
-import { useRequestPublicKeys } from './useRequestPublicKeys';
 
 export function useUploadEncryptedShards() {
   const { selectedArchaeologists, requiredArchaeologists } = useSelector(x => x.embalmState);
@@ -12,9 +11,8 @@ export function useUploadEncryptedShards() {
     useContext(CreateSarcophagusContext);
 
   const { uploadToArweave } = useArweaveService();
-  const { requestPublicKeys } = useRequestPublicKeys();
 
-  const uploadAndSetEncryptedShards = useCallback(async (isRetry: boolean) => {
+  const uploadAndSetEncryptedShards = useCallback(async () => {
     try {
       // Step 1: Split the outer layer private key using shamirs secret sharing
       const shards: Uint8Array[] = split(outerPrivateKey, {
@@ -24,11 +22,7 @@ export function useUploadEncryptedShards() {
 
       // Step 2: Encrypt each shard of the outer layer private key using each archaeologist's public
       // key
-      const archPublicKeys = await requestPublicKeys(selectedArchaeologists, isRetry);
-
-      if (archPublicKeys.length < selectedArchaeologists.length) {
-        throw new Error('Not enough public keys');
-      }
+      const archPublicKeys = selectedArchaeologists.map(arch => arch.publicKey!);
 
       const encShards = await encryptShards(archPublicKeys, shards);
 
@@ -52,7 +46,6 @@ export function useUploadEncryptedShards() {
     requiredArchaeologists,
     outerPrivateKey,
     selectedArchaeologists,
-    requestPublicKeys,
     uploadToArweave,
     setArchaeologistShards,
     setEncryptedShardsTxId,

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadEncryptedShards.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadEncryptedShards.ts
@@ -25,6 +25,11 @@ export function useUploadEncryptedShards() {
       // Step 2: Encrypt each shard of the outer layer private key using each archaeologist's public
       // key
       const archPublicKeys = await requestPublicKeys(selectedArchaeologists);
+
+      if (archPublicKeys.length < selectedArchaeologists.length) {
+        throw new Error('Not enough public keys');
+      }
+
       const encShards = await encryptShards(archPublicKeys, shards);
 
       // Step 3: Create a mapping of arch public keys -> encrypted shards; upload to arweave

--- a/src/features/embalm/stepContent/utils/createSarcophagus.ts
+++ b/src/features/embalm/stepContent/utils/createSarcophagus.ts
@@ -19,6 +19,7 @@ export async function encryptShards(
 export enum CreateSarcophagusStage {
   NOT_STARTED,
   DIAL_ARCHAEOLOGISTS,
+  GET_PUBLIC_KEYS,
   UPLOAD_ENCRYPTED_SHARDS,
   ARCHAEOLOGIST_NEGOTIATION,
   UPLOAD_PAYLOAD,
@@ -31,6 +32,7 @@ export enum CreateSarcophagusStage {
 export const defaultCreateSarcophagusStages: Record<number, string> = {
   [CreateSarcophagusStage.NOT_STARTED]: '',
   [CreateSarcophagusStage.DIAL_ARCHAEOLOGISTS]: 'Connect to Archaeologists',
+  [CreateSarcophagusStage.GET_PUBLIC_KEYS]: 'Request Archaeologist Public Keys',
   [CreateSarcophagusStage.UPLOAD_ENCRYPTED_SHARDS]: 'Upload Archaeologist Data to Arweave',
   [CreateSarcophagusStage.ARCHAEOLOGIST_NEGOTIATION]: 'Retrieve Archaeologist Signatures',
   [CreateSarcophagusStage.UPLOAD_PAYLOAD]: 'Upload File Data to Arweave',

--- a/src/hooks/libp2p/useBootLibp2pNode.ts
+++ b/src/hooks/libp2p/useBootLibp2pNode.ts
@@ -20,7 +20,7 @@ import { useLibp2p } from './useLibp2p';
 export function useBootLibp2pNode(discoveryPeriod?: number) {
   const dispatch = useDispatch();
   const globalLibp2pNode = useSelector(s => s.appState.libp2pNode);
-  const { onPeerConnect, onPeerDisconnect, onPeerDiscovery } = useLibp2p();
+  const { onPeerDisconnect, onPeerDiscovery } = useLibp2p();
 
   const createAndStartNode = useCallback(async (): Promise<Libp2p> => {
     const newLibp2pNode = await createLibp2p(nodeConfig);
@@ -32,7 +32,6 @@ export function useBootLibp2pNode(discoveryPeriod?: number) {
   const addNodeEventListeners = useCallback(
     (libp2pNode: Libp2p): void => {
       libp2pNode.addEventListener('peer:discovery', onPeerDiscovery);
-      libp2pNode.connectionManager.addEventListener('peer:connect', onPeerConnect);
       libp2pNode.connectionManager.addEventListener('peer:disconnect', onPeerDisconnect);
 
       // TODO: Remove this once we refactor how libp2p works
@@ -45,7 +44,7 @@ export function useBootLibp2pNode(discoveryPeriod?: number) {
         }, discoveryPeriod);
       }
     },
-    [onPeerDiscovery, onPeerConnect, onPeerDisconnect, discoveryPeriod]
+    [onPeerDiscovery, onPeerDisconnect, discoveryPeriod]
   );
 
   useEffect(() => {

--- a/src/hooks/libp2p/useLibp2p.ts
+++ b/src/hooks/libp2p/useLibp2p.ts
@@ -1,33 +1,20 @@
 import { Connection } from '@libp2p/interface-connection';
 import { PeerInfo } from '@libp2p/interface-peer-info';
-import { StreamHandler } from '@libp2p/interface-registrar';
-import { ethers } from 'ethers';
-import { pipe } from 'it-pipe';
 import { useCallback } from 'react';
 import {
   setArchaeologistConnection,
   setArchaeologistFullPeerId,
   setArchaeologistOnlineStatus,
-  setArchaeologistPublicKey,
 } from 'store/embalm/actions';
-import { useDispatch, useSelector } from 'store/index';
-import { log } from '../../lib/utils/logger';
-import { PUBLIC_KEY_STREAM } from '../../lib/config/node_config';
+import { useDispatch } from 'store/index';
 
 // TODO -- temporarily removed while we have the 20 second discovery limit
 // values used to determine if an archaeologist is online
 // const pingThreshold = 60000;
 // const heartbeatTimeouts: Record<string, NodeJS.Timeout | undefined> = {};
 
-interface PublicKeyResponseFromArchaeologist {
-  signature: string;
-  encryptionPublicKey: string;
-}
-
 export function useLibp2p() {
   const dispatch = useDispatch();
-  const libp2pNode = useSelector(s => s.appState.libp2pNode);
-  const { selectedArchaeologists } = useSelector(s => s.embalmState);
 
   const onPeerDiscovery = useCallback(
     (evt: CustomEvent<PeerInfo>) => {
@@ -68,60 +55,9 @@ export function useLibp2p() {
     [dispatch]
   );
 
-  const handlePublicKeyStream: StreamHandler = useCallback(
-    ({ stream }) => {
-      pipe(stream, async function (source) {
-        for await (const msg of source) {
-          try {
-            const decoded = new TextDecoder().decode(msg.subarray());
-            log(`received public key ${decoded}`);
-
-            const publicKeyResponse: PublicKeyResponseFromArchaeologist = JSON.parse(decoded);
-
-            const signerAddress = ethers.utils.verifyMessage(
-              publicKeyResponse.encryptionPublicKey,
-              publicKeyResponse.signature
-            );
-
-            const arch = selectedArchaeologists.find(a => a.profile.archAddress === signerAddress);
-            if (arch) {
-              if (arch.profile.peerId !== arch.fullPeerId!.toString()) {
-                // TODO -- handle error state here, will need to communicate to user
-                console.error('arch peer ID does not match profile:', signerAddress);
-              }
-              dispatch(
-                setArchaeologistPublicKey(
-                  arch.fullPeerId!.toString(),
-                  publicKeyResponse.encryptionPublicKey
-                )
-              );
-            } else {
-              // TODO -- handle error state here, will need to communicate to user
-              console.error('signature does not map to a selected archaeologist:', signerAddress);
-            }
-          } catch (e) {
-            console.error(e);
-          }
-        }
-      }).finally(() => {
-        // clean up resources
-        console.log('closing the pub key stream');
-        stream.close();
-      });
-    },
-    [selectedArchaeologists, dispatch]
-  );
-
-  const resetPublicKeyStream = useCallback(async () => {
-    await libp2pNode?.unhandle(PUBLIC_KEY_STREAM);
-    await libp2pNode?.handle([PUBLIC_KEY_STREAM], handlePublicKeyStream);
-  }, [handlePublicKeyStream, libp2pNode]);
-
   return {
     onPeerDiscovery,
     onPeerConnect,
     onPeerDisconnect,
-    handlePublicKeyStream,
-    resetPublicKeyStream,
   };
 }

--- a/src/hooks/libp2p/useLibp2p.ts
+++ b/src/hooks/libp2p/useLibp2p.ts
@@ -39,14 +39,6 @@ export function useLibp2p() {
     [dispatch]
   );
 
-  const onPeerConnect = useCallback(
-    (evt: CustomEvent<Connection>) => {
-      const peerId = evt.detail.remotePeer.toString();
-      setTimeout(() => dispatch(setArchaeologistConnection(peerId, evt.detail)), 500);
-    },
-    [dispatch]
-  );
-
   const onPeerDisconnect = useCallback(
     (evt: CustomEvent<Connection>) => {
       const peerId = evt.detail.remotePeer.toString();
@@ -57,7 +49,6 @@ export function useLibp2p() {
 
   return {
     onPeerDiscovery,
-    onPeerConnect,
     onPeerDisconnect,
   };
 }

--- a/src/hooks/libp2p/useLibp2p.ts
+++ b/src/hooks/libp2p/useLibp2p.ts
@@ -55,7 +55,7 @@ export function useLibp2p() {
   const onPeerConnect = useCallback(
     (evt: CustomEvent<Connection>) => {
       const peerId = evt.detail.remotePeer.toString();
-      dispatch(setArchaeologistConnection(peerId, evt.detail));
+      setTimeout(() => dispatch(setArchaeologistConnection(peerId, evt.detail)), 500);
     },
     [dispatch]
   );

--- a/src/store/embalm/actions.ts
+++ b/src/store/embalm/actions.ts
@@ -26,7 +26,6 @@ export enum ActionType {
   SetName = 'EMBALM_SET_NAME',
   SetNegotiationTimestamp = 'EMBALM_SET_NEGOTIATION_TIMESTAMP',
   SetOuterLayerKeys = 'EMBALM_SET_OUTER_LAYER_KEYS',
-  SetPublicKeysReady = 'EMBALM_SET_PUBLIC_KEYS_READY',
   SetRecipientState = 'EMBALM_SET_RECIPIENT_STATE',
   SetRequiredArchaeologists = 'EMBALM_SET_REQUIRED_ARCHAEOLOGISTS',
   SetResurrection = 'EMBALM_SET_RESURRECTION',
@@ -91,7 +90,6 @@ type EmbalmPayload = {
   [ActionType.SetName]: { name: string };
   [ActionType.SetNegotiationTimestamp]: { negotiationTimestamp: number };
   [ActionType.SetOuterLayerKeys]: { privateKey: string; publicKey: string };
-  [ActionType.SetPublicKeysReady]: { publicKeysReady: boolean };
   [ActionType.SetRecipientState]: RecipientState;
   [ActionType.SetRequiredArchaeologists]: { count: number };
   [ActionType.SetResurrection]: { resurrection: number };


### PR DESCRIPTION
Based on #214

This PR decouple initial connection to archaeologist node from public key request.
It should be merged (and tested) with [this PR](https://github.com/sarcophagus-org/sarcophagus-v2-archaeologist-service/pull/64).

I also updated `retryStage` to set a retry flag. Each stage can now use this to make decisions on what to do differently. Currently this is only being used by `initiateSarcophagusNegotiation`
EDIT: Added use for retry in `useRequestPublicKeys`, called by `uploadAndSetEncryptedShards`