### PR TITLE
213 update setpendingbalance to handle multiple bundlr transactions

### DIFF
--- a/src/features/bundlr/BundlrProfile.tsx
+++ b/src/features/bundlr/BundlrProfile.tsx
@@ -5,6 +5,7 @@ import { useGetBalance } from 'features/embalm/stepContent/hooks/useGetBalance';
 import { useEthBalance } from 'hooks/useEthBalance';
 import { useEthPrice } from 'hooks/useEthPrice';
 import { useState } from 'react';
+import { useSelector } from 'store/index';
 import { BundlrInput } from './BundlrInput';
 
 export enum BundlrAction {
@@ -22,6 +23,7 @@ interface BundlrProfileProps {
 
 export function BundlrProfile({ action, onDeposit, onWithdraw, onConnect }: BundlrProfileProps) {
   const [amount, setAmount] = useState('');
+  const { balanceOffset } = useSelector(s => s.bundlrState);
   const bundlrBalanceData = useGetBalance();
   const bundlrBalance = !bundlrBalanceData?.balance
     ? '--'
@@ -78,6 +80,14 @@ export function BundlrProfile({ action, onDeposit, onWithdraw, onConnect }: Bund
       >
         {isNaN(bundlrUsdValue) ? '--' : `$${bundlrUsdValue}`}
       </Text>
+      {balanceOffset !== 0 && (
+        <Text
+          mt={3}
+          color="yellow"
+        >
+          You have a pending balance update. Your balance should be updated in a few minutes.
+        </Text>
+      )}
       <Text
         mt={6}
         color="whiteAlpha.700"

--- a/src/features/embalm/stepContent/components/Bundlr.tsx
+++ b/src/features/embalm/stepContent/components/Bundlr.tsx
@@ -2,31 +2,29 @@ import {
   Button,
   FormControl,
   FormLabel,
-  InputGroup,
+  HStack,
   Input,
+  InputGroup,
   InputRightElement,
   Text,
   VStack,
-  HStack,
 } from '@chakra-ui/react';
+import { ethers } from 'ethers';
 import { useBundlr } from 'features/embalm/stepContent/hooks/useBundlr';
 import { useUploadPrice } from 'features/embalm/stepNavigator/hooks/useUploadPrice';
-import { useCallback, useState } from 'react';
-import { setBalance } from 'store/bundlr/actions';
-import { useDispatch, useSelector } from 'store/index';
 import { uploadPriceDecimals } from 'lib/constants';
-import { ethers } from 'ethers';
+import { useCallback, useState } from 'react';
+import { useSelector } from 'store/index';
 import { useBundlrSession } from '../hooks/useBundlrSession';
 import { useGetBalance } from '../hooks/useGetBalance';
 
 export function Bundlr({ children }: { children?: React.ReactNode }) {
-  const dispatch = useDispatch();
   const { fund, isFunding } = useBundlr();
   const { connectToBundlr, isConnected, disconnectFromBundlr } = useBundlrSession();
-  const { getBalance, formattedBalance } = useGetBalance();
+  const { formattedBalance } = useGetBalance();
   const { uploadPrice, formattedUploadPrice, uploadPriceBN } = useUploadPrice();
   const [amount, setAmount] = useState(parseFloat(uploadPrice || '0').toFixed(uploadPriceDecimals));
-  const { pendingBalance } = useSelector(x => x.bundlrState);
+  const { balanceOffset } = useSelector(x => x.bundlrState);
 
   const isAmountValid = parseFloat(amount) > 0;
 
@@ -44,9 +42,7 @@ export function Bundlr({ children }: { children?: React.ReactNode }) {
   const handleFund = useCallback(async () => {
     if (!isAmountValid) return;
     await fund(amount);
-    const newBalance = await getBalance();
-    dispatch(setBalance(newBalance));
-  }, [amount, dispatch, fund, getBalance, isAmountValid]);
+  }, [amount, fund, isAmountValid]);
 
   return (
     <VStack
@@ -121,7 +117,7 @@ export function Bundlr({ children }: { children?: React.ReactNode }) {
               <Text variant="secondary">Estimated payload price: {formattedUploadPrice}</Text>
             )}
           </VStack>
-          {pendingBalance.txId && (
+          {balanceOffset !== 0 && (
             <Text
               mt={3}
               color="error"

--- a/src/features/embalm/stepContent/hooks/useGetBalance.ts
+++ b/src/features/embalm/stepContent/hooks/useGetBalance.ts
@@ -1,16 +1,17 @@
 import { bundlrBalanceDecimals } from 'lib/constants';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { setBalance, setPendingBalance } from 'store/bundlr/actions';
+import { useCallback, useEffect, useMemo } from 'react';
+import { resetBalanceOffset, setBalance } from 'store/bundlr/actions';
 import { useDispatch, useSelector } from 'store/index';
 import { useNetwork } from 'wagmi';
 import { useBundlr } from './useBundlr';
 
+const fetchBalanceTimeout = 5_000;
+
 export function useGetBalance() {
   const dispatch = useDispatch();
   const { bundlr } = useBundlr();
-  const { balance, isConnected, pendingBalance } = useSelector(x => x.bundlrState);
+  const { balance, isConnected, balanceOffset } = useSelector(x => x.bundlrState);
   const { chain } = useNetwork();
-  const [intervalId, setIntervalId] = useState<NodeJS.Timer | null>(null);
 
   const formattedBalance = useMemo(
     () =>
@@ -32,6 +33,7 @@ export function useGetBalance() {
     return converted.toString();
   }, [bundlr]);
 
+  // Effect that loads the balance when the component mounts and if the bundlr is instantiated
   useEffect(() => {
     (async () => {
       if (bundlr) {
@@ -43,45 +45,46 @@ export function useGetBalance() {
     })();
   }, [bundlr, dispatch, getBalance]);
 
+  // Effect that runs an interval which queries the bundlr balance if the balanceOffset is not 0. If
+  // the balance coming from the bundlr turns out to match the current balance plus the
+  // balanceOffset, this indicates that the balance has been properly updated and the balanceOffset
+  // is reset to 0, thus causing the contents of the interval to be skipped. The interval will start
+  // again if fund or withdraw is called, which will (usually) set the balanceOffset to a non-zero
+  // value.
   useEffect(() => {
-    const queryBalance = async () => {
-      try {
+    const timeoutId = setInterval(async () => {
+      if (balanceOffset !== 0) {
         const newBalance = await getBalance();
-        console.log('querying balance');
-        // If our new balance is different than current, then funding is complete
-        // update the new balance and clear out our interval
-        if (newBalance !== balance) {
-          console.log('balance is being updated due to funding completion');
-          dispatch(
-            setPendingBalance({
-              balanceBeforeFund: '',
-              txId: '',
-            })
-          );
-          dispatch(setBalance(newBalance));
+        console.log('balanceOffset: ', balanceOffset);
+        // Check if the sum of the balance stored in state and the balance offset is equal to the
+        // new balance. This indicates that the balance has finally been updated to the expected
+        // amount.
+        //
+        // Note that this solution still has a significant fault: If the user funds for 1 ETH and
+        // then withdraws for 1 ETH, the app will think that the pending balance has been resolved
+        // because the sum of the balance stored in state and the balance offset is equal to the new
+        // balance, even though the balance hasn't technically been updated yet. The fund action may
+        // have been applied immediately while the withdraw action could take another 20 min to
+        // apply. Tracking the balance through an array of pending transactions as we were
+        // previously would produce the same fault.
+        //
+        // The only way to reliably track if the balance is pending is for the Bundlr to tell us
+        // that the balance is pending, which it doesn't do at this time. On mainnet, the balance is
+        // updated much more quickly than on testnet, so this issue is not as big of a deal on
+        // mainnet.
+        if (parseFloat(balance) + balanceOffset === parseFloat(newBalance)) {
+          dispatch(resetBalanceOffset());
         }
-      } catch (error) {
-        console.error(error);
+
+        // Set the balance to the retreived balance on each interval
+        dispatch(setBalance(newBalance));
       }
+    }, fetchBalanceTimeout);
+
+    return () => {
+      clearInterval(timeoutId);
     };
-
-    if (pendingBalance.txId) {
-      if (!intervalId) {
-        const id = setInterval(() => {
-          queryBalance();
-        }, 5000);
-        setIntervalId(id);
-      }
-    } else {
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
-    }
-
-    if (intervalId) {
-      return () => clearInterval(intervalId);
-    }
-  }, [pendingBalance.txId, balance, dispatch, getBalance, intervalId]);
+  }, [balance, balanceOffset, dispatch, getBalance]);
 
   return { balance, getBalance, formattedBalance };
 }

--- a/src/features/embalm/stepContent/hooks/useGetBalance.ts
+++ b/src/features/embalm/stepContent/hooks/useGetBalance.ts
@@ -55,23 +55,9 @@ export function useGetBalance() {
     const timeoutId = setInterval(async () => {
       if (balanceOffset !== 0) {
         const newBalance = await getBalance();
-        console.log('balanceOffset: ', balanceOffset);
         // Check if the sum of the balance stored in state and the balance offset is equal to the
         // new balance. This indicates that the balance has finally been updated to the expected
         // amount.
-        //
-        // Note that this solution still has a significant fault: If the user funds for 1 ETH and
-        // then withdraws for 1 ETH, the app will think that the pending balance has been resolved
-        // because the sum of the balance stored in state and the balance offset is equal to the new
-        // balance, even though the balance hasn't technically been updated yet. The fund action may
-        // have been applied immediately while the withdraw action could take another 20 min to
-        // apply. Tracking the balance through an array of pending transactions as we were
-        // previously would produce the same fault.
-        //
-        // The only way to reliably track if the balance is pending is for the Bundlr to tell us
-        // that the balance is pending, which it doesn't do at this time. On mainnet, the balance is
-        // updated much more quickly than on testnet, so this issue is not as big of a deal on
-        // mainnet.
         if (parseFloat(balance) + balanceOffset === parseFloat(newBalance)) {
           dispatch(resetBalanceOffset());
         }

--- a/src/hooks/useEthPrice.ts
+++ b/src/hooks/useEthPrice.ts
@@ -11,24 +11,29 @@ export function useEthPrice() {
     const cacheLength = 60_000 * 5; // 5 minutes
 
     (async () => {
-      // Epoch timestamp for when the eth price cache expires
-      const cacheExpiration = localStorage.getItem('eth_price_expiration');
+      try {
+        // Epoch timestamp for when the eth price cache expires
+        const cacheExpiration = localStorage.getItem('eth_price_expiration');
 
-      // Determines if the eth price cache is expired and should be fetched again
-      const isCacheExpired = parseInt(cacheExpiration || '0') + cacheLength < new Date().getTime();
+        // Determines if the eth price cache is expired and should be fetched again
+        const isCacheExpired =
+          parseInt(cacheExpiration || '0') + cacheLength < new Date().getTime();
 
-      if (ethPrice === '0' || isCacheExpired) {
-        // TODO: Replace this api call with one that has higher rate limits.
-        // Fetch the eth price from CoinGecko
-        const response = await fetch(
-          'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd'
-        );
-        const data = await response.json();
-        setEthPrice(data.ethereum.usd);
+        if (ethPrice === '0' || isCacheExpired) {
+          // TODO: Replace this api call with one that has higher rate limits.
+          // Fetch the eth price from CoinGecko
+          const response = await fetch(
+            'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd'
+          );
+          const data = await response.json();
+          setEthPrice(data.ethereum.usd);
 
-        // Store the eth price and cache expiration in local storage
-        localStorage.setItem('eth_price', data.ethereum.usd);
-        localStorage.setItem('eth_price_expiration', new Date().getTime().toString());
+          // Store the eth price and cache expiration in local storage
+          localStorage.setItem('eth_price', data.ethereum.usd);
+          localStorage.setItem('eth_price_expiration', new Date().getTime().toString());
+        }
+      } catch (error) {
+        // do nothing
       }
     })();
   }, [ethPrice]);

--- a/src/store/bundlr/actions.ts
+++ b/src/store/bundlr/actions.ts
@@ -1,27 +1,30 @@
 import { WebBundlr } from '@bundlr-network/client';
 import { ActionMap } from '../ActionMap';
-import { BundlrPendingBalance } from './reducer';
 
 // NOTE: Prefix each action with this namespace. Duplicate action names in other reducers will cause
 // unexpected behavior.
 export enum ActionType {
   Connect = 'BUNDLR_CONNECT',
   Disconnect = 'BUNDLR_DISCONNECT',
+  Fund = 'BUNDLR_FUND',
+  SetBalance = 'BUNDLR_SET_BALANCE',
   SetBundlr = 'BUNDLR_SET',
-  SetBalance = 'EMBALM_SET_BALANCE',
-  SetIsFunding = 'EMBALM_SET_IS_FUNDING',
-  SetPendingBalance = 'EMBALM_SET_PENDING_BALANCE',
+  SetIsFunding = 'BUNDLR_SET_IS_FUNDING',
   SetTxId = 'BUNDLR_SET_TX_ID',
+  Withdraw = 'BUNDLR_WITHDRAW',
+  ResetBalanceOffset = 'BUNDLR_RESET_BALANCE_OFFSET',
 }
 
 type BundlrPayload = {
   [ActionType.Connect]: {};
   [ActionType.Disconnect]: {};
-  [ActionType.SetBundlr]: { bundlr: WebBundlr | null };
+  [ActionType.Fund]: { amount: string };
   [ActionType.SetBalance]: { balance: string };
+  [ActionType.SetBundlr]: { bundlr: WebBundlr | null };
   [ActionType.SetIsFunding]: { isFunding: boolean };
-  [ActionType.SetPendingBalance]: { pendingBalance: BundlrPendingBalance };
   [ActionType.SetTxId]: { txId: string };
+  [ActionType.Withdraw]: { amount: string };
+  [ActionType.ResetBalanceOffset]: {};
 };
 
 export function connect(): BundlrActions {
@@ -65,12 +68,28 @@ export function setIsFunding(isFunding: boolean): BundlrActions {
   };
 }
 
-export function setPendingBalance(pendingBalance: BundlrPendingBalance): BundlrActions {
+export function fund(amount: string): BundlrActions {
   return {
-    type: ActionType.SetPendingBalance,
+    type: ActionType.Fund,
     payload: {
-      pendingBalance,
+      amount,
     },
+  };
+}
+
+export function withdraw(amount: string): BundlrActions {
+  return {
+    type: ActionType.Withdraw,
+    payload: {
+      amount,
+    },
+  };
+}
+
+export function resetBalanceOffset(): BundlrActions {
+  return {
+    type: ActionType.ResetBalanceOffset,
+    payload: {},
   };
 }
 

--- a/src/store/bundlr/reducer.ts
+++ b/src/store/bundlr/reducer.ts
@@ -2,11 +2,6 @@ import { WebBundlr } from '@bundlr-network/client';
 import { Actions } from '..';
 import { ActionType } from './actions';
 
-export interface BundlrPendingBalance {
-  txId: string | null;
-  balanceBeforeFund: string;
-}
-
 export interface BundlrState {
   balance: string;
   bundlr: WebBundlr | null;
@@ -14,7 +9,7 @@ export interface BundlrState {
   isFunding: boolean;
   isUploading: boolean;
   txId: string | null;
-  pendingBalance: BundlrPendingBalance;
+  balanceOffset: number;
 }
 
 export const bundlrInitialState: BundlrState = {
@@ -24,10 +19,7 @@ export const bundlrInitialState: BundlrState = {
   isFunding: false,
   isUploading: false,
   txId: null,
-  pendingBalance: {
-    txId: null,
-    balanceBeforeFund: '',
-  },
+  balanceOffset: 0,
 };
 
 export function bundlrReducer(state: BundlrState, action: Actions): BundlrState {
@@ -52,8 +44,14 @@ export function bundlrReducer(state: BundlrState, action: Actions): BundlrState 
       const txId = action.payload.txId;
       return { ...state, txId };
 
-    case ActionType.SetPendingBalance:
-      return { ...state, pendingBalance: action.payload.pendingBalance };
+    case ActionType.Fund:
+      return { ...state, balanceOffset: state.balanceOffset + parseFloat(action.payload.amount) };
+
+    case ActionType.Withdraw:
+      return { ...state, balanceOffset: state.balanceOffset - parseFloat(action.payload.amount) };
+
+    case ActionType.ResetBalanceOffset:
+      return { ...state, balanceOffset: 0 };
 
     default:
       return state;


### PR DESCRIPTION
# Bundlr pending balance update 

Adds support for calculating pending Bundlr balance with multiple transactions. 

### Context
The Goerli Bundlr sometimes takes a long time to update the balance after a fund or withdraw (sometimes 20 min or more). Bundlr also has no way of telling us that a balance is pending. To deal with this we need keep track of the pending balance in state so we may display to the user that their balance is pending.

### Changes 
Instead of tracking what the pending balance should be, we are keeping a tally of what the balance offset is. If your current balance is `1.0` and you fund the bundlr for `0.1` then the `balanceOffset` will be `0.1`. If you then withdraw `0.5` the `balanceOffset` will be `-0.4`. If the balance from state plus the balance offset is equal to the balance from bundlr, then its somewhat safe to assume that the balance has been updated. 

There are cases where you fund for 0.1 then withdraw for 0.1, in which case the `balanceOffset` will be 0 and the pending status will not be shown to the user even though the balance is technically pending. The only way to address this is for Bundlr to tell us that the balance is pending, which it doesn't do. 

There is an interval that fetches the balance from Bundlr every 5 seconds if the balance offset is not 0. 

### Testing 
Testing for this is very difficult, since it depends on the Bundlr working slowly to test properly and an update can take up to 20 min to fund or withdraw. I wrote my own mock functions (not included in this PR) to mock the Bundlr's `fund`, `withdraw`, and `getBalance` methods. To test yourself: 
1. In the embalm process, fund the bundlr 
2. Go to the Bundlr page and do a withdraw. 
3. After the fund transaction resolves, the balance will likely take some time to update, in which case a message will display that the balance is pending. 