### PR TITLE
Add recipient public key derivation page

### DIFF
--- a/src/features/recipients/components/CopyPublicKey.tsx
+++ b/src/features/recipients/components/CopyPublicKey.tsx
@@ -1,0 +1,39 @@
+import { CheckIcon, CopyIcon } from '@chakra-ui/icons';
+import { Button, Text, useClipboard } from '@chakra-ui/react';
+
+interface CopyPublicKeyProps {
+  publicKey: string;
+}
+
+export function CopyPublicKey({ publicKey }: CopyPublicKeyProps) {
+  const { onCopy, hasCopied } = useClipboard(publicKey, {
+    timeout: 5000,
+  });
+
+  return (
+    <>
+      <Text variant="secondary">
+        Sarcophagus has derived your public key! You can copy this and send to embalmers interested
+        in creating sarcophagi for you.
+      </Text>
+      <Text
+        p={5}
+        mt={6}
+        border="1px solid"
+        borderColor="brand.700"
+        variant="secondary"
+        h="150px"
+      >
+        {publicKey}
+      </Text>
+      <Button
+        mt={6}
+        py={6}
+        leftIcon={!hasCopied ? <CopyIcon /> : <CheckIcon />}
+        onClick={onCopy}
+      >
+        Copy to Clipbard
+      </Button>
+    </>
+  );
+}

--- a/src/features/recipients/components/GetPublicKey.tsx
+++ b/src/features/recipients/components/GetPublicKey.tsx
@@ -1,0 +1,26 @@
+import { Button, Text } from '@chakra-ui/react';
+
+interface GetPublicKeyProps {
+  onClickGetPublicKey?: () => void;
+  isLoading?: boolean;
+}
+
+export function GetPublicKey({ onClickGetPublicKey, isLoading }: GetPublicKeyProps) {
+  return (
+    <>
+      <Text variant="secondary">
+        Click the button below to digitally sign a message with your connected wallet so that
+        Sarcophagus can derive your public key. Send that key to any embalmers interested in
+        creating sarcophagi for you.
+      </Text>
+      <Button
+        mt={6}
+        py={6}
+        onClick={onClickGetPublicKey}
+        isLoading={isLoading}
+      >
+        Get Public Key
+      </Button>
+    </>
+  );
+}

--- a/src/features/recipients/components/RecipientPublicKey.tsx
+++ b/src/features/recipients/components/RecipientPublicKey.tsx
@@ -1,0 +1,44 @@
+import { Flex, Text } from '@chakra-ui/react';
+import { usePublicKey } from '../hooks/usePublicKey';
+import { CopyPublicKey } from './CopyPublicKey';
+import { GetPublicKey } from './GetPublicKey';
+
+export function RecipientPublicKey() {
+  const { publicKey, signMessage, isLoading } = usePublicKey();
+
+  function handleGetPublicKey() {
+    signMessage();
+  }
+
+  return (
+    <Flex
+      w="500px"
+      border="1px solid"
+      borderColor="whiteAlpha.300"
+      direction="column"
+    >
+      <Flex
+        justify="center"
+        w="100%"
+        bg="whiteAlpha.400"
+        py={3}
+      >
+        <Text fontSize="md">RECIPIENT PUBLIC KEY</Text>
+      </Flex>
+      <Flex
+        direction="column"
+        px={9}
+        py={6}
+      >
+        {publicKey === '' ? (
+          <GetPublicKey
+            onClickGetPublicKey={handleGetPublicKey}
+            isLoading={isLoading}
+          />
+        ) : (
+          <CopyPublicKey publicKey={publicKey} />
+        )}
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/features/recipients/hooks/usePublicKey.ts
+++ b/src/features/recipients/hooks/usePublicKey.ts
@@ -1,0 +1,39 @@
+import { useToast } from '@chakra-ui/react';
+import { arrayify, hashMessage, recoverPublicKey } from 'ethers/lib/utils';
+import { publicKeyRetrieved } from 'lib/utils/toast';
+import { useState } from 'react';
+import { useSignMessage } from 'wagmi';
+
+// A hook that uses wagmi's signMessge and ethers' recoverPublicKey to get the public key of a wallet
+export function usePublicKey() {
+  const toast = useToast();
+  const [publicKey, setPublicKey] = useState('');
+
+  const message = 'Sign this message to retrieve your public key.';
+
+  // Prompts for user to sign a message. The signature is used to derive the wallet public key.
+  const {
+    error,
+    isLoading,
+    signMessage: wagmiSignMessage,
+  } = useSignMessage({
+    onSuccess(data, variables) {
+      const signature = data;
+
+      // Get the public key from the message and the signature.
+      const recoveredPublicKey = recoverPublicKey(
+        arrayify(hashMessage(Buffer.from(variables.message))),
+        signature
+      );
+      setPublicKey(recoveredPublicKey);
+      toast(publicKeyRetrieved());
+    },
+  });
+
+  // Sign the given message using wagmi's signMessage
+  function signMessage() {
+    wagmiSignMessage({ message });
+  }
+
+  return { publicKey, signMessage, error, isLoading };
+}

--- a/src/lib/utils/toast.ts
+++ b/src/lib/utils/toast.ts
@@ -241,3 +241,10 @@ export const cleanFailure = (): UseToastOptions => ({
   duration,
   position,
 });
+
+export const publicKeyRetrieved = (): UseToastOptions => ({
+  title: 'Public key successfully retrieved!',
+  status: 'success',
+  duration,
+  position,
+});

--- a/src/pages/RecipientsPage.tsx
+++ b/src/pages/RecipientsPage.tsx
@@ -1,0 +1,10 @@
+import { Center } from '@chakra-ui/react';
+import { RecipientPublicKey } from 'features/recipients/components/RecipientPublicKey';
+
+export function RecipientsPage() {
+  return (
+    <Center mt={12}>
+      <RecipientPublicKey />
+    </Center>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,24 +10,27 @@ import { DetailsPage } from './DetailsPage';
 import { EmbalmPage } from './EmbalmPage';
 import { BundlrPage } from './BundlrPage';
 import { TempResurrectionPage } from './TempResurrectionPage';
+import { RecipientsPage } from './RecipientsPage';
 import pharaoh from 'assets/images/pharaoh.gif';
 import { useSupportedNetwork } from 'lib/config/useSupportedNetwork';
 
 export enum RouteKey {
-  EMBALM_PAGE,
-  DASHBOARD_PAGE,
-  DASHBOARD_DETAIL,
   ARCHEOLOGIST_PAGE,
   BUNDLER_PAGE,
+  DASHBOARD_DETAIL,
+  DASHBOARD_PAGE,
+  EMBALM_PAGE,
+  RECIPIENTS,
   TEMP_RESURRECTION_PAGE,
 }
 
 export const RoutesPathMap: { [key: number]: string } = {
-  [RouteKey.EMBALM_PAGE]: '/embalm',
-  [RouteKey.DASHBOARD_PAGE]: '/dashboard',
-  [RouteKey.DASHBOARD_DETAIL]: '/dashboard/:id',
   [RouteKey.ARCHEOLOGIST_PAGE]: '/archaeologists',
   [RouteKey.BUNDLER_PAGE]: '/fundbundlr',
+  [RouteKey.DASHBOARD_DETAIL]: '/dashboard/:id',
+  [RouteKey.DASHBOARD_PAGE]: '/dashboard',
+  [RouteKey.EMBALM_PAGE]: '/embalm',
+  [RouteKey.RECIPIENTS]: '/recipients',
   [RouteKey.TEMP_RESURRECTION_PAGE]: '/temp-resurrection',
 };
 
@@ -80,6 +83,11 @@ export function Pages() {
       element: <TempResurrectionPage />,
       label: 'TempResurrectionPage',
       hidden: true,
+    },
+    {
+      path: RoutesPathMap[RouteKey.RECIPIENTS],
+      element: <RecipientsPage />,
+      label: 'Recipients',
     },
   ];
 


### PR DESCRIPTION
# Derive recipient's public key 

This adds the page to derive a recipient's public key. This is intended to be used as an optional tool for the recipient to derive a public key that they may send to an embalmer.

![image](https://user-images.githubusercontent.com/34484576/202803815-1f907dbb-48f4-4638-97b6-8affaa50fd48.png)
