### PR TITLE
Hit Enter to go next

### DIFF
--- a/src/features/embalm/stepContent/components/SarcophagusName.tsx
+++ b/src/features/embalm/stepContent/components/SarcophagusName.tsx
@@ -15,6 +15,7 @@ export function SarcophagusName() {
         <FormLabel>Name</FormLabel>
         <Input
           onChange={handleNameChange}
+          autoFocus
           value={name}
           maxLength={maxSarcophagusNameLength}
         />

--- a/src/features/embalm/stepContent/hooks/useEnterToNextStep.ts
+++ b/src/features/embalm/stepContent/hooks/useEnterToNextStep.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { Step } from 'store/embalm/reducer';
+import { useSarcophagusParameters } from './useSarcophagusParameters';
+import { useStepContent } from './useStepContent';
+
+/**
+ * Adds an "Enter" keydown event listener that goes to the 
+ * next step in the create sarco form if `canGoNext` is true
+ * */
+export function useEnterToNextStep() {
+    const { goToNext, currentStep } = useStepContent();
+    const { sarcophagusParameters } = useSarcophagusParameters();
+
+    useEffect(() => {
+        if (currentStep === Step.CreateSarcophagus) return;
+
+        const currentStepParams = sarcophagusParameters.find(s => s.step === currentStep);
+
+        const canGoNext = currentStep === Step.NameSarcophagus ?
+            !currentStepParams?.error && !sarcophagusParameters.find(s => s.name === 'RESURRECTION')?.error :
+            !currentStepParams?.error;
+
+        const keyDownHandler = (event: any) => {
+            if (event.key === 'Enter' && canGoNext) {
+                event.preventDefault();
+                goToNext();
+            }
+        };
+
+        document.addEventListener('keydown', keyDownHandler);
+
+        return () => {
+            document.removeEventListener('keydown', keyDownHandler);
+        };
+    }, [goToNext, currentStep, sarcophagusParameters]);
+}

--- a/src/features/embalm/stepContent/hooks/useSarcophagusParameters.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcophagusParameters.ts
@@ -9,6 +9,7 @@ import {
   humanizeUnixTimestamp,
 } from '../../../../lib/utils/helpers';
 import moment from 'moment';
+import { minimumResurrection } from 'lib/constants';
 
 export interface SarcophagusParameter {
   name: string;
@@ -40,6 +41,15 @@ export const useSarcophagusParameters = () => {
   const isHardhatNetwork = chainId === hardhatChainId;
   const maxRewrapIntervalMs = getLowestRewrapInterval(selectedArchaeologists) * 1000;
 
+  const resurrectionTimeError = !resurrection
+    ? 'Please set a resurrection time'
+    : resurrection > maxRewrapIntervalMs + Date.now()
+      ? 'The resurrection time you have selected is beyond the maximum rewrap interval of your selected archaeologists'
+      : resurrection - minimumResurrection < Date.now() && resurrection !== 0 ?
+        `Resurrection must be ${moment
+          .duration(minimumResurrection)
+          .humanize()} or more in the future.` : null;
+
   const sarcophagusParameters: SarcophagusParameter[] = [
     {
       name: 'NAME',
@@ -51,11 +61,7 @@ export const useSarcophagusParameters = () => {
       name: 'RESURRECTION',
       value: resurrection ? humanizeUnixTimestamp(resurrection) : null,
       step: Step.NameSarcophagus,
-      error: !resurrection
-        ? 'Please set a resurrection time'
-        : resurrection > maxRewrapIntervalMs + Date.now()
-        ? 'The resurrection time you have selected is beyond the maximum rewrap interval of your selected archaeologists'
-        : null,
+      error: resurrectionTimeError,
     },
     {
       name: 'MAXIMUM REWRAP INTERVAL',

--- a/src/features/embalm/stepContent/index.tsx
+++ b/src/features/embalm/stepContent/index.tsx
@@ -10,6 +10,7 @@ import { TotalRequiredArchaegologists } from './steps/TotalRequiredArchaeologist
 import { UploadPayload } from './steps/UploadPayload';
 import { CreateSarcophagus } from './steps/CreateSarcophagus';
 import { CreateSarcophagusContextProvider } from './context/CreateSarcophagusContext';
+import { useEnterToNextStep } from './hooks/useEnterToNextStep';
 
 interface StepContentMap {
   component: JSX.Element;
@@ -19,6 +20,7 @@ interface StepContentMap {
 export function StepContent() {
   const { currentStep, goToPrev, goToNext } = useStepContent();
   const areStepsDisabled = useSelector(x => x.embalmState.areStepsDisabled);
+  useEnterToNextStep();
 
   // Manages which page to render based on the currentStep in the store
   const contentMap: { [key: number]: StepContentMap } = {

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -145,6 +145,6 @@ export function buildResurrectionDateString(
   const msUntilResurrection = resurrectionTime.toNumber() * 1000 - Date.now();
   const humanizedDuration = moment.duration(msUntilResurrection).humanize();
   const timeUntilResurrection =
-    msUntilResurrection < 0 ? `-${humanizedDuration}` : humanizedDuration;
+    msUntilResurrection < 0 ? `${humanizedDuration} ago` : humanizedDuration;
   return `${resurrectionDateString} (${timeUntilResurrection})`;
 }


### PR DESCRIPTION
This PR adds functionality to allow users to hit ENTER to go to the next step.

Ended up using a hook that is called from `StepContent`. ENTER will move to the next step only if the current step is error-free.

For the Name Sarcophagus step, even though the Summary screen separates "Name" and "Resurrection" steps, I've had to handle both as if they were the same step, since as far as the form is concerned, they are. (see `canGoNext` in `useEnterToNextStep`). While doing this I also ended up fixing the resurrection time error bug (not showing if resurrection time is in past).