### PR TITLE
Claim fixes

### DIFF
--- a/src/features/embalm/stepContent/hooks/useEnterToNextStep.ts
+++ b/src/features/embalm/stepContent/hooks/useEnterToNextStep.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEnterKeyCallback } from 'hooks/useEnterKeyCallback';
 import { Step } from 'store/embalm/reducer';
 import { useSarcophagusParameters } from './useSarcophagusParameters';
 import { useStepContent } from './useStepContent';
@@ -11,7 +11,7 @@ export function useEnterToNextStep() {
   const { goToNext, currentStep } = useStepContent();
   const { sarcophagusParameters } = useSarcophagusParameters();
 
-  useEffect(() => {
+  useEnterKeyCallback(() => {
     if (currentStep === Step.CreateSarcophagus) return;
 
     const currentStepParams = sarcophagusParameters.find(s => s.step === currentStep);
@@ -19,20 +19,12 @@ export function useEnterToNextStep() {
     const canGoNext =
       currentStep === Step.NameSarcophagus
         ? !currentStepParams?.error &&
-          !sarcophagusParameters.find(s => s.name === 'RESURRECTION')?.error
+        !sarcophagusParameters.find(s => s.name === 'RESURRECTION')?.error
         : !currentStepParams?.error;
 
-    const keyDownHandler = (event: any) => {
-      if (event.key === 'Enter' && canGoNext) {
-        event.preventDefault();
-        goToNext();
-      }
-    };
 
-    document.addEventListener('keydown', keyDownHandler);
-
-    return () => {
-      document.removeEventListener('keydown', keyDownHandler);
-    };
-  }, [goToNext, currentStep, sarcophagusParameters]);
+    if (canGoNext) {
+      goToNext();
+    }
+  });
 }

--- a/src/features/embalm/stepContent/hooks/useEnterToNextStep.ts
+++ b/src/features/embalm/stepContent/hooks/useEnterToNextStep.ts
@@ -19,9 +19,8 @@ export function useEnterToNextStep() {
     const canGoNext =
       currentStep === Step.NameSarcophagus
         ? !currentStepParams?.error &&
-        !sarcophagusParameters.find(s => s.name === 'RESURRECTION')?.error
+          !sarcophagusParameters.find(s => s.name === 'RESURRECTION')?.error
         : !currentStepParams?.error;
-
 
     if (canGoNext) {
       goToNext();

--- a/src/features/resurrection/hooks/useResurrection.ts
+++ b/src/features/resurrection/hooks/useResurrection.ts
@@ -31,7 +31,11 @@ export function useResurrection(sarcoId: string, recipientPrivateKey: string) {
   /**
    * Resurrects the sarcohpagus using the values passed in to the hook
    */
-  const resurrect = useCallback(async (): Promise<{ fileName: string; data: string }> => {
+  const resurrect = useCallback(async (): Promise<{
+    fileName: string;
+    data: string;
+    error?: string;
+  }> => {
     setIsResurrecting(true);
     try {
       if (!canResurrect) {
@@ -77,12 +81,17 @@ export function useResurrection(sarcoId: string, recipientPrivateKey: string) {
       const { fileName, data } = JSON.parse(decryptedPayload.toString());
 
       if (!fileName || !data) {
-        throw new Error('The payload is missing the fileName or data');
+        return { fileName, data, error: 'The payload is missing the fileName or data' };
       }
 
       return { fileName, data };
     } catch (error) {
-      throw new Error(`Error resurrecting sarcophagus: ${error}`);
+      console.error(`Error resurrecting sarcophagus: ${error}`);
+      return {
+        fileName: '',
+        data: '',
+        error: 'Could not claim Sarcophagus. Please make sure you have the right private key.',
+      };
     } finally {
       setIsResurrecting(false);
     }

--- a/src/features/sarcophagi/components/Claim.tsx
+++ b/src/features/sarcophagi/components/Claim.tsx
@@ -24,8 +24,12 @@ export function Claim() {
     isLoading: isLoadingResurrection,
   } = useResurrection(id || ethers.constants.HashZero, privateKey);
 
+  const privateKeyPad = (privKey: string): string => {
+    return privKey.startsWith('0x') ? privKey : `0x${privKey}`;
+  };
+
   const handleChangePrivateKey = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setPrivateKey(e.target.value);
+    setPrivateKey(privateKeyPad(e.target.value.trim()));
   };
 
   // linkRef is used to automatically trigger a download
@@ -60,6 +64,7 @@ export function Claim() {
                 value={privateKey}
                 onChange={handleChangePrivateKey}
                 placeholder="0x0000..."
+                _placeholder={{ color: 'text.secondary' }}
               />
               <Text mt={2}>Please enter the Private Key to decrypt the Sarcophagus</Text>
               <Button

--- a/src/features/sarcophagi/components/Claim.tsx
+++ b/src/features/sarcophagi/components/Claim.tsx
@@ -2,6 +2,7 @@ import { Button, Center, Flex, Link, Spinner, Text, Textarea } from '@chakra-ui/
 import { SarcoAlert } from 'components/SarcoAlert';
 import { BigNumber, ethers } from 'ethers';
 import { useResurrection } from 'features/resurrection/hooks/useResurrection';
+import { useEnterKeyCallback } from 'hooks/useEnterKeyCallback';
 import { useGetSarcophagusDetails } from 'hooks/viewStateFacet';
 import { buildResurrectionDateString } from 'lib/utils/helpers';
 import { useRef, useState } from 'react';
@@ -51,6 +52,8 @@ export function Claim() {
       linkRef.current.click();
     }
   }
+
+  useEnterKeyCallback(handleResurrect);
 
   return (
     <Flex

--- a/src/features/sarcophagi/components/Claim.tsx
+++ b/src/features/sarcophagi/components/Claim.tsx
@@ -10,6 +10,7 @@ import { useParams } from 'react-router-dom';
 export function Claim() {
   const { id } = useParams();
   const [privateKey, setPrivateKey] = useState('');
+  const [resurrectError, setResurrectError] = useState('');
   const { sarcophagus, isLoading: isLoadingSarcophagus } = useGetSarcophagusDetails({
     sarcoId: id,
   });
@@ -35,7 +36,14 @@ export function Claim() {
   // linkRef is used to automatically trigger a download
   const linkRef = useRef<HTMLAnchorElement>(null);
   async function handleResurrect() {
-    const { fileName, data } = await resurrect();
+    setResurrectError('');
+
+    const { fileName, data, error } = await resurrect();
+    if (error) {
+      setResurrectError(error);
+      return;
+    }
+
     const dataUrl = data.toString();
     if (linkRef.current) {
       linkRef.current.href = dataUrl;
@@ -66,7 +74,16 @@ export function Claim() {
                 placeholder="0x0000..."
                 _placeholder={{ color: 'text.secondary' }}
               />
-              <Text mt={2}>Please enter the Private Key to decrypt the Sarcophagus</Text>
+              {resurrectError ? (
+                <Text
+                  mt={2}
+                  textColor="red"
+                >
+                  {resurrectError}
+                </Text>
+              ) : (
+                <Text mt={2}>Please enter the Private Key to decrypt the Sarcophagus</Text>
+              )}
               <Button
                 w="fit-content"
                 disabled={!canResurrect}

--- a/src/features/sarcophagi/components/SarcoTable.tsx
+++ b/src/features/sarcophagi/components/SarcoTable.tsx
@@ -13,13 +13,14 @@ enum SortableColumn {
 
 interface SarcoTableProps {
   ids?: string[];
+  isClaimTab?: boolean;
 }
 
 /**
  * A table meant to be used to display sarcophagi with fixed column headers. Accepts sarcophagus ids
  * and pulls them from the contract.
  */
-export function SarcoTable({ ids }: SarcoTableProps) {
+export function SarcoTable({ ids, isClaimTab }: SarcoTableProps) {
   const [sortColumnId, setSortColumnId] = useState<SortableColumn>(SortableColumn.None);
   const [sortDirection, setSortDirection] = useState<SortDirection>(SortDirection.None);
 
@@ -126,6 +127,7 @@ export function SarcoTable({ ids }: SarcoTableProps) {
             <SarcoTableRow
               key={sarco.id}
               sarco={sarco}
+              isClaimTab={isClaimTab}
             />
           ))}
         </Tbody>

--- a/src/features/sarcophagi/components/SarcoTableRow.tsx
+++ b/src/features/sarcophagi/components/SarcoTableRow.tsx
@@ -17,12 +17,13 @@ export enum SarcoAction {
 
 export interface SarcophagusTableRowProps extends TableRowProps {
   sarco: Sarcophagus;
+  isClaimTab?: boolean;
 }
 
 /**
  * Custom TableRow component to be used in place of the default Tr component. Adds a sort icon.
  */
-export function SarcoTableRow({ sarco }: SarcophagusTableRowProps) {
+export function SarcoTableRow({ sarco, isClaimTab }: SarcophagusTableRowProps) {
   const { address } = useAccount();
   const navigate = useNavigate();
 
@@ -49,8 +50,8 @@ export function SarcoTableRow({ sarco }: SarcophagusTableRowProps) {
     };
   } = {
     [SarcophagusState.Active]: {
-      action: isEmbalmer ? SarcoAction.Rewrap : undefined,
-      tooltip: 'Extend the resurrection date of the Sarcophagus',
+      action: isEmbalmer && !isClaimTab ? SarcoAction.Rewrap : undefined,
+      tooltip: isEmbalmer && !isClaimTab ? 'Extend the resurrection date of the Sarcophagus' : '',
       stateTooltip: 'The Sarcophagus is on course to be resurrected',
     },
     [SarcophagusState.Failed]: {
@@ -59,8 +60,8 @@ export function SarcoTableRow({ sarco }: SarcophagusTableRowProps) {
       stateTooltip: 'Too few archeologists unwrapped the Sarcophagus. It can no longer be claimed.',
     },
     [SarcophagusState.Resurrected]: {
-      action: !isRecipient ? SarcoAction.Claim : undefined,
-      tooltip: !isRecipient ? 'Decrypt and download the Sarcophagus payload' : '',
+      action: isRecipient && isClaimTab ? SarcoAction.Claim : undefined,
+      tooltip: isRecipient && isClaimTab ? 'Decrypt and download the Sarcophagus payload' : '',
       stateTooltip: 'The Sarcophagus has been resurrected can be claimed',
     },
     [SarcophagusState.Accused]: {

--- a/src/features/sarcophagi/index.tsx
+++ b/src/features/sarcophagi/index.tsx
@@ -71,7 +71,10 @@ export function Sarcophagi() {
         >
           <TabPanel h="100%">{embalmerPanel()}</TabPanel>
           <TabPanel h="100%">
-            <SarcoTable ids={recipientSarcophagi} isClaimTab />
+            <SarcoTable
+              ids={recipientSarcophagi}
+              isClaimTab
+            />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/src/features/sarcophagi/index.tsx
+++ b/src/features/sarcophagi/index.tsx
@@ -71,7 +71,7 @@ export function Sarcophagi() {
         >
           <TabPanel h="100%">{embalmerPanel()}</TabPanel>
           <TabPanel h="100%">
-            <SarcoTable ids={recipientSarcophagi} />
+            <SarcoTable ids={recipientSarcophagi} isClaimTab />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/src/hooks/useEnterKeyCallback.ts
+++ b/src/hooks/useEnterKeyCallback.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+/**
+ * Adds an "Enter" keydown event listener
+ */
+export function useEnterKeyCallback(callback: Function) {
+    useEffect(() => {
+        const keyDownHandler = (event: any) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                callback();
+            }
+        };
+
+        document.addEventListener('keydown', keyDownHandler);
+
+        return () => {
+            document.removeEventListener('keydown', keyDownHandler);
+        };
+    }, [callback]);
+}

--- a/src/hooks/useEnterKeyCallback.ts
+++ b/src/hooks/useEnterKeyCallback.ts
@@ -4,18 +4,18 @@ import { useEffect } from 'react';
  * Adds an "Enter" keydown event listener
  */
 export function useEnterKeyCallback(callback: Function) {
-    useEffect(() => {
-        const keyDownHandler = (event: any) => {
-            if (event.key === 'Enter') {
-                event.preventDefault();
-                callback();
-            }
-        };
+  useEffect(() => {
+    const keyDownHandler = (event: any) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        callback();
+      }
+    };
 
-        document.addEventListener('keydown', keyDownHandler);
+    document.addEventListener('keydown', keyDownHandler);
 
-        return () => {
-            document.removeEventListener('keydown', keyDownHandler);
-        };
-    }, [callback]);
+    return () => {
+      document.removeEventListener('keydown', keyDownHandler);
+    };
+  }, [callback]);
 }


### PR DESCRIPTION
This PR fixes a couple of bugs when pasting private key in order to claim, and a bug with claim button visibility.

Claim action is never visible on my sarcophagi tab:
<img width="1219" alt="Screenshot 2022-11-29 at 15 33 48" src="https://user-images.githubusercontent.com/7101382/204572798-67f66e43-e7b3-4d5b-8e6a-16e2131acc81.png">

Claim action clickable from claim tab. Rewrap action never visible from here:
<img width="1205" alt="Screenshot 2022-11-29 at 15 34 52" src="https://user-images.githubusercontent.com/7101382/204573020-23932b6b-52df-4bca-9d75-353f09db7ab3.png">



Also refactored `useEnterToNextStep` to add a `useEnterKeyCallback` that can now be used anywhere to do run a callback when the ENTER key is pressed.