### PR TITLE
Handle Switching Accounts

### DIFF
--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useClearSarcophagusState.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useClearSarcophagusState.ts
@@ -51,7 +51,7 @@ export function useClearSarcophagusState() {
     setArchaeologistSignatures(initialCreateSarcophagusState.archaeologistSignatures);
     setSarcophagusPayloadTxId(initialCreateSarcophagusState.sarcophagusPayloadTxId);
     setSarcophagusTxId(initialCreateSarcophagusState.sarcophagusTxId);
-
+    console.log('resetting state');
     // reset global embalm state
     dispatch(resetEmbalmState(Step.CreateSarcophagus));
 

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useClearSarcophagusState.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useClearSarcophagusState.ts
@@ -51,7 +51,7 @@ export function useClearSarcophagusState() {
     setArchaeologistSignatures(initialCreateSarcophagusState.archaeologistSignatures);
     setSarcophagusPayloadTxId(initialCreateSarcophagusState.sarcophagusPayloadTxId);
     setSarcophagusTxId(initialCreateSarcophagusState.sarcophagusTxId);
-    console.log('resetting state');
+
     // reset global embalm state
     dispatch(resetEmbalmState(Step.CreateSarcophagus));
 

--- a/src/pages/WalletDisconnectPage.tsx
+++ b/src/pages/WalletDisconnectPage.tsx
@@ -1,0 +1,66 @@
+import { Image, Text, Button, Container, Heading } from '@chakra-ui/react';
+import { useAccount } from 'wagmi';
+import pharaoh from 'assets/images/pharaoh.gif';
+import { useConnectModal } from '@rainbow-me/rainbowkit';
+import { useSupportedNetwork } from 'lib/config/useSupportedNetwork';
+import { useClearSarcophagusState } from 'features/embalm/stepContent/hooks/useCreateSarcophagus/useClearSarcophagusState';
+import { useDispatch } from 'store/index';
+import { useEffect } from 'react';
+import { goToStep } from 'store/embalm/actions';
+import { Step } from 'store/embalm/reducer';
+import { useBundlrSession } from 'features/embalm/stepContent/hooks/useBundlrSession';
+
+export function WalletDisconnectPage() {
+  const { isConnected, address } = useAccount();
+  const { openConnectModal } = useConnectModal();
+  const { supportedNetworkNames } = useSupportedNetwork();
+  const { disconnectFromBundlr } = useBundlrSession();
+
+  const { clearSarcophagusState } = useClearSarcophagusState();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!address) {
+      clearSarcophagusState();
+      disconnectFromBundlr();
+      dispatch(goToStep(Step.NameSarcophagus));
+    }
+  }, [address, clearSarcophagusState, disconnectFromBundlr, dispatch]);
+
+  return (
+    <Container
+      maxW="sm"
+      centerContent
+    >
+      <Heading pb={2}>{!isConnected ? 'No Wallet Detected' : 'Unsupported Network'}</Heading>
+      <Text align="center">
+        {!isConnected
+          ? 'Please connect to your web3 wallet to access this dapp.'
+          : 'Please connect to a supported network.'}
+      </Text>
+      <Image
+        src={pharaoh}
+        w="125px"
+        py={8}
+      />
+      {!isConnected ? (
+        <Button onClick={openConnectModal}>Connect Wallet</Button>
+      ) : (
+        <Text
+          align="center"
+          variant="bold"
+        >
+          Supported Networks
+          {supportedNetworkNames.map(network => (
+            <Text
+              fontWeight="normal"
+              key={network}
+            >
+              {network}
+            </Text>
+          ))}
+        </Text>
+      )}
+    </Container>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,17 +1,6 @@
-import {
-  Box,
-  Button,
-  Flex,
-  Link,
-  Text,
-  Heading,
-  Image,
-  Container,
-  Tooltip,
-} from '@chakra-ui/react';
+import { Box, Button, Flex, Link, Text, Tooltip } from '@chakra-ui/react';
 import { ConnectWalletButton } from 'components/ConnectWalletButton';
 import { useAccount } from 'wagmi';
-import { useConnectModal } from '@rainbow-me/rainbowkit';
 import { Navigate, NavLink, Route, Routes, BrowserRouter as Router } from 'react-router-dom';
 import { Navbar } from '../components/Navbar';
 import { ArchaeologistsPage } from './ArchaeologistsPage';
@@ -22,15 +11,11 @@ import { BundlrPage } from './BundlrPage';
 import { TempResurrectionPage } from './TempResurrectionPage';
 import { RecipientsPage } from './RecipientsPage';
 import { ThemeTestPage } from './ThemeTestPage';
-import pharaoh from 'assets/images/pharaoh.gif';
 import { useSupportedNetwork } from 'lib/config/useSupportedNetwork';
 import { SarcophagusCreatedPage } from './SarcophagusCreatedPage';
 import { NotFoundPage } from './NotFoundPage';
-import { useCallback, useEffect } from 'react';
-import { useClearSarcophagusState } from 'features/embalm/stepContent/hooks/useCreateSarcophagus/useClearSarcophagusState';
-import { goToStep } from 'store/embalm/actions';
-import { Step } from 'store/embalm/reducer';
-import { useDispatch, useSelector } from 'store/index';
+import { CreateSarcophagusContextProvider } from 'features/embalm/stepContent/context/CreateSarcophagusContext';
+import { WalletDisconnectPage } from './WalletDisconnectPage';
 
 export enum RouteKey {
   ARCHEOLOGIST_PAGE,
@@ -57,10 +42,6 @@ export const RoutesPathMap: { [key: number]: string } = {
 };
 
 export function Pages() {
-  const { clearSarcophagusState } = useClearSarcophagusState();
-  const dispatch = useDispatch();
-  const { name } = useSelector(x => x.embalmState);
-
   const routes = [
     {
       path: RoutesPathMap[RouteKey.EMBALM_PAGE],
@@ -136,24 +117,7 @@ export function Pages() {
 
   const { isConnected } = useAccount();
 
-  console.log('name', name);
-
-  const clearState = useCallback(() => {
-    clearSarcophagusState();
-
-    console.log('callback clear state');
-    dispatch(goToStep(Step.NameSarcophagus));
-  }, [clearSarcophagusState, dispatch]);
-
-  const { address } = useAccount({});
-
-  useEffect(() => {
-    if (!!address) clearState();
-  }, [clearState, address]);
-
-  const { isSupportedChain, supportedNetworkNames } = useSupportedNetwork();
-
-  const { openConnectModal } = useConnectModal();
+  const { isSupportedChain } = useSupportedNetwork();
 
   return (
     <Router>
@@ -230,42 +194,9 @@ export function Pages() {
               />
             </Routes>
           ) : (
-            <Container
-              maxW="sm"
-              centerContent
-            >
-              <Heading pb={2}>
-                {!isConnected ? 'No Wallet Detected' : 'Unsupported Network'}
-              </Heading>
-              <Text align="center">
-                {!isConnected
-                  ? 'Please connect to your web3 wallet to access this dapp.'
-                  : 'Please connect to a supported network.'}
-              </Text>
-              <Image
-                src={pharaoh}
-                w="125px"
-                py={8}
-              />
-              {!isConnected ? (
-                <Button onClick={openConnectModal}>Connect Wallet</Button>
-              ) : (
-                <Text
-                  align="center"
-                  variant="bold"
-                >
-                  Supported Networks
-                  {supportedNetworkNames.map(network => (
-                    <Text
-                      fontWeight="normal"
-                      key={network}
-                    >
-                      {network}
-                    </Text>
-                  ))}
-                </Text>
-              )}
-            </Container>
+            <CreateSarcophagusContextProvider>
+              <WalletDisconnectPage />
+            </CreateSarcophagusContextProvider>
           )}
         </Flex>
       </Flex>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,6 +26,11 @@ import pharaoh from 'assets/images/pharaoh.gif';
 import { useSupportedNetwork } from 'lib/config/useSupportedNetwork';
 import { SarcophagusCreatedPage } from './SarcophagusCreatedPage';
 import { NotFoundPage } from './NotFoundPage';
+import { useCallback, useEffect } from 'react';
+import { useClearSarcophagusState } from 'features/embalm/stepContent/hooks/useCreateSarcophagus/useClearSarcophagusState';
+import { goToStep } from 'store/embalm/actions';
+import { Step } from 'store/embalm/reducer';
+import { useDispatch, useSelector } from 'store/index';
 
 export enum RouteKey {
   ARCHEOLOGIST_PAGE,
@@ -52,6 +57,10 @@ export const RoutesPathMap: { [key: number]: string } = {
 };
 
 export function Pages() {
+  const { clearSarcophagusState } = useClearSarcophagusState();
+  const dispatch = useDispatch();
+  const { name } = useSelector(x => x.embalmState);
+
   const routes = [
     {
       path: RoutesPathMap[RouteKey.EMBALM_PAGE],
@@ -126,6 +135,21 @@ export function Pages() {
   ];
 
   const { isConnected } = useAccount();
+
+  console.log('name', name);
+
+  const clearState = useCallback(() => {
+    clearSarcophagusState();
+
+    console.log('callback clear state');
+    dispatch(goToStep(Step.NameSarcophagus));
+  }, [clearSarcophagusState, dispatch]);
+
+  const { address } = useAccount({});
+
+  useEffect(() => {
+    if (!!address) clearState();
+  }, [clearState, address]);
 
   const { isSupportedChain, supportedNetworkNames } = useSupportedNetwork();
 


### PR DESCRIPTION
### Overview

When signing out of your wallet during the embalm process:
- the state gets cleared
- bundlr signout (only if accounts are switched)
- back to step 1 'Name Sarco'

Created a Wallet Disconnect Page with the above functionality, and wrapped around it the CreateSarcophagusContextProvider