### PR TITLE
Restyle toasts option 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@ajna/pagination": "^1.4.19",
         "@bundlr-network/client": "^0.9.0-b8",
         "@chainsafe/libp2p-noise": "^10.0.0",
+        "@chakra-ui/anatomy": "^2.1.0",
         "@chakra-ui/icons": "^2.0.11",
         "@chakra-ui/react": "^2.2.3",
         "@chakra-ui/styled-system": "^2.3.5",
@@ -2194,8 +2195,9 @@
       }
     },
     "node_modules/@chakra-ui/anatomy": {
-      "version": "2.0.4",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.1.0.tgz",
+      "integrity": "sha512-E3jMPGqKuGTbt7mKtc8g/MOOenw2c4wqRC1vOypyFgmC8wsewdY+DJJNENF3atXAK7p5VMBKQfZ7ipNlHnDAwA=="
     },
     "node_modules/@chakra-ui/avatar": {
       "version": "2.0.9",
@@ -3004,6 +3006,16 @@
       "peerDependencies": {
         "@chakra-ui/styled-system": ">=2.0.0"
       }
+    },
+    "node_modules/@chakra-ui/theme-tools/node_modules/@chakra-ui/anatomy": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.0.4.tgz",
+      "integrity": "sha512-wWLvPrLOCO+nDb+cMcEJ/iDxgWEizRXOlIZCinCzkeEYhcWibINx6wh49uVUyMT/dIs/JTHQ4mUb9IzqJ1RY+g=="
+    },
+    "node_modules/@chakra-ui/theme/node_modules/@chakra-ui/anatomy": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.0.4.tgz",
+      "integrity": "sha512-wWLvPrLOCO+nDb+cMcEJ/iDxgWEizRXOlIZCinCzkeEYhcWibINx6wh49uVUyMT/dIs/JTHQ4mUb9IzqJ1RY+g=="
     },
     "node_modules/@chakra-ui/toast": {
       "version": "3.0.6",
@@ -29375,7 +29387,9 @@
       }
     },
     "@chakra-ui/anatomy": {
-      "version": "2.0.4"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.1.0.tgz",
+      "integrity": "sha512-E3jMPGqKuGTbt7mKtc8g/MOOenw2c4wqRC1vOypyFgmC8wsewdY+DJJNENF3atXAK7p5VMBKQfZ7ipNlHnDAwA=="
     },
     "@chakra-ui/avatar": {
       "version": "2.0.9",
@@ -29888,6 +29902,13 @@
         "@chakra-ui/anatomy": "2.0.4",
         "@chakra-ui/theme-tools": "2.0.9",
         "@chakra-ui/utils": "2.0.8"
+      },
+      "dependencies": {
+        "@chakra-ui/anatomy": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.0.4.tgz",
+          "integrity": "sha512-wWLvPrLOCO+nDb+cMcEJ/iDxgWEizRXOlIZCinCzkeEYhcWibINx6wh49uVUyMT/dIs/JTHQ4mUb9IzqJ1RY+g=="
+        }
       }
     },
     "@chakra-ui/theme-tools": {
@@ -29896,6 +29917,13 @@
         "@chakra-ui/anatomy": "2.0.4",
         "@chakra-ui/utils": "2.0.8",
         "@ctrl/tinycolor": "^3.4.0"
+      },
+      "dependencies": {
+        "@chakra-ui/anatomy": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.0.4.tgz",
+          "integrity": "sha512-wWLvPrLOCO+nDb+cMcEJ/iDxgWEizRXOlIZCinCzkeEYhcWibINx6wh49uVUyMT/dIs/JTHQ4mUb9IzqJ1RY+g=="
+        }
       }
     },
     "@chakra-ui/toast": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@ajna/pagination": "^1.4.19",
     "@bundlr-network/client": "^0.9.0-b8",
     "@chainsafe/libp2p-noise": "^10.0.0",
+    "@chakra-ui/anatomy": "^2.1.0",
     "@chakra-ui/icons": "^2.0.11",
     "@chakra-ui/react": "^2.2.3",
     "@chakra-ui/styled-system": "^2.3.5",

--- a/src/components/ConnectWalletButton.tsx
+++ b/src/components/ConnectWalletButton.tsx
@@ -24,10 +24,10 @@ export function ConnectWalletButton() {
               <Flex>
                 <Button
                   variant="ghost"
-                  _hover={{ bgColor: 'menuBlue.1000' }}
-                  _focus={{ bgColor: 'menuBlue.1000' }}
+                  _hover={{ bgColor: 'grayBlue.700' }}
+                  _focus={{ bgColor: 'grayBlue.700' }}
                   cursor="auto"
-                  bg="menuBlue.1000"
+                  bg="grayBlue.1000"
                   mx={2}
                   leftIcon={<SarcoTokenIcon />}
                 >
@@ -47,7 +47,7 @@ export function ConnectWalletButton() {
                   ml={2}
                   variant="ghost"
                   icon={<DotsMenuIcon />}
-                  bg="menuBlue.1000"
+                  bg="grayBlue.1000"
                   aria-label="more"
                 />
               </Flex>

--- a/src/components/SarcoAlert/index.tsx
+++ b/src/components/SarcoAlert/index.tsx
@@ -17,10 +17,10 @@ interface AlertProps {
 }
 
 const StatusMap = {
-  info: { icon: InfoIcon, color: 'alert.info' },
-  warning: { icon: WarningIcon, color: 'alert.warning' },
-  success: { icon: SuccessIcon, color: 'alert.success' },
-  error: { icon: ErrorIcon, color: 'alert.error' },
+  info: { icon: InfoIcon, color: 'blue' },
+  warning: { icon: WarningIcon, color: 'orange' },
+  success: { icon: SuccessIcon, color: 'green' },
+  error: { icon: ErrorIcon, color: 'red' },
   loading: { icon: InfoIcon, color: 'black' }, // not supported
 };
 
@@ -38,7 +38,13 @@ export function SarcoAlert(props: AlertProps & HTMLChakraProps<'div'>) {
   const hasTitle = !!title;
   const StatusIcon = getStatusIcon(status);
   return (
-    <Alert {...props}>
+    <Alert
+      {...props}
+      // Required to override the default css border styling for the toasts in src/theme/styles.ts
+      style={{
+        border: 'none',
+      }}
+    >
       <Grid
         alignItems={hasTitle ? 'flex-start' : 'center'}
         templateAreas={

--- a/src/components/TableText.tsx
+++ b/src/components/TableText.tsx
@@ -8,7 +8,7 @@ interface TableTextProps extends TextProps {
 export function TableText({ children, ...props }: TableTextProps) {
   return (
     <Center
-      bg="table.textBackground"
+      bg="grayBlue.950"
       py="2px"
       borderRadius="2px"
       w="fit-content"

--- a/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
@@ -41,9 +41,9 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
         <Flex px={3}>
           <HStack direction="row">
             <Checkbox
-              colorScheme="checkboxScheme"
+              variant="brand"
               onChange={() => selectAndReset()}
-            ></Checkbox>
+            />
             <HStack>
               <Text>
                 Show

--- a/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
@@ -62,12 +62,11 @@ export function ArchaeologistListItem({
                   dispatch(deselectArchaeologist(archaeologist.profile.archAddress));
                 }
               }}
-              colorScheme="checkboxScheme"
             ></Checkbox>
           )}
           <Text
             ml={3}
-            bg={'table.textBackground'}
+            bg={'grayBlue.950'}
             color={rowTextColor}
             py={0.5}
             px={2}
@@ -86,7 +85,7 @@ export function ArchaeologistListItem({
 
   return (
     <Tr
-      background={isSelected ? (archaeologist.exception ? 'errorHighlight' : 'brand.50') : ''}
+      background={isSelected ? (archaeologist.exception ? 'background.red' : 'brand.50') : ''}
       onClick={() => handleClickRow()}
       cursor="pointer"
       _hover={isSelected ? {} : { background: 'brand.0' }}

--- a/src/features/embalm/stepContent/components/ReviewSarcophagusTable.tsx
+++ b/src/features/embalm/stepContent/components/ReviewSarcophagusTable.tsx
@@ -39,7 +39,7 @@ export function ReviewSarcophagusTable() {
                     py={0.5}
                     mr={2}
                     rounded="sm"
-                    bg={error ? 'table.errorBackground' : 'table.textBackground'}
+                    bg={error ? 'background.red' : 'grayBlue.950'}
                   >
                     {name}
                   </Text>
@@ -53,7 +53,7 @@ export function ReviewSarcophagusTable() {
                   px={2}
                   py={0.5}
                   rounded="sm"
-                  bg={error ? 'table.errorBackground' : 'table.textBackground'}
+                  bg={error ? 'background.red' : 'grayBlue.950'}
                 >
                   {value || '----'}
                 </Text>

--- a/src/features/embalm/stepContent/components/SummaryErrorIcon.tsx
+++ b/src/features/embalm/stepContent/components/SummaryErrorIcon.tsx
@@ -12,7 +12,7 @@ export function SummaryErrorIcon({ error }: { error?: string }) {
         h="1.2rem"
         w="1.2rem"
         borderRadius={100}
-        background="errorAlt"
+        background="background.red"
         alignItems="center"
         justifyContent="center"
       >
@@ -20,7 +20,7 @@ export function SummaryErrorIcon({ error }: { error?: string }) {
           h="1.2rem"
           w="1.2rem"
           borderRadius={100}
-          background="errorAlt"
+          background="background.red"
           alignItems="center"
           justifyContent="center"
           color="red"

--- a/src/lib/utils/toast.ts
+++ b/src/lib/utils/toast.ts
@@ -6,79 +6,73 @@ import { maxFileSize } from 'lib/constants';
 import prettyBytes from 'pretty-bytes';
 import { formatToastMessage } from './helpers';
 
-const duration = 5000;
-const position = 'bottom-right';
+const defaultOptions: Partial<UseToastOptions> = {
+  duration: 5000,
+  isClosable: true,
+  position: 'bottom-right',
+};
 
 export const infoSample = (): UseToastOptions => ({
   title: 'Toast message',
   description: 'This is some info',
   status: 'info',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const successSample = (): UseToastOptions => ({
   title: 'Toast message',
   description: 'This is a success',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const warningSample = (): UseToastOptions => ({
   title: 'Toast message',
   description: 'This is a warning',
   status: 'warning',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const errorSample = (): UseToastOptions => ({
   title: 'Toast message',
   description: 'This is an error',
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const connectStart = (): UseToastOptions => ({
   title: 'Attempting to Connect',
   description: 'Attempting to connect to the Bundlr node...',
   status: 'info',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const connectSuccess = (): UseToastOptions => ({
   title: 'Connection Successful',
   description: 'Successfully connected to the Bundlr node',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const connectFailure = (errorMessage: string): UseToastOptions => ({
   title: 'Failed to connect to Bundlr',
   description: formatToastMessage(errorMessage),
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const disconnect = (): UseToastOptions => ({
   title: 'Disconnected',
   description: 'Disconnected from the Bundlr node',
   status: 'info',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const fundStart = (): UseToastOptions => ({
   title: 'Funding...',
   description: 'Funding the Bundlr node',
   status: 'info',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const fundSuccess = (): UseToastOptions => ({
@@ -86,165 +80,144 @@ export const fundSuccess = (): UseToastOptions => ({
   description:
     'Bundlr transaction is confirmed. It may take a few minutes for your Bundlr balance to update.',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const fundFailure = (errorMessage: string): UseToastOptions => ({
   title: 'Funding failed',
   description: formatToastMessage(errorMessage),
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const withdrawStart = (): UseToastOptions => ({
   title: 'Withdrawing...',
   description: 'Withdrawing balance from the Bundlr node',
   status: 'info',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const withdrawSuccess = (): UseToastOptions => ({
   title: 'Withdraw Successful!',
   description: 'Successfully withdrew funds from Bundlr node',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const withdrawFailure = (errorMessage: string): UseToastOptions => ({
   title: 'Withdraw failed',
   description: formatToastMessage(errorMessage),
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const uploadStart = (): UseToastOptions => ({
   title: 'Uploading...',
   description: 'Uploading file to the Bundlr node',
   status: 'info',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const uploadSuccess = (): UseToastOptions => ({
   title: 'Upload Successful!',
   description: 'Successful uploaded file to Bundlr node',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const uploadFailure = (errorMessage: string): UseToastOptions => ({
   title: 'Upload failed',
   description: formatToastMessage(errorMessage),
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const fileTooBig = (): UseToastOptions => ({
   title: 'File too big',
   description: `Your file size must not exceed ${prettyBytes(maxFileSize)}.`,
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const payloadSaveSuccess = (): UseToastOptions => ({
   title: 'Payload saved',
   description: 'Your payload has been saved for a later step.',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const generateOuterKeys = (): UseToastOptions => ({
   title: 'Keys generated',
   description: 'A new pair of encryption keys have been generated.',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const generateOuterKeysFailure = (errorMessage: string): UseToastOptions => ({
   title: 'Failed to generate keys',
   description: formatToastMessage(errorMessage),
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const dialArchaeologistSuccess = (): UseToastOptions => ({
   title: 'Connected Successfully!',
   description: 'Connected to archaeologist',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const dialArchaeologistFailure = (): UseToastOptions => ({
   title: 'Connection failed',
   description: 'Unable to connect to archaeologist',
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const rewrapSuccess = (): UseToastOptions => ({
   title: 'Rewrap Successful!',
   description: 'Your sarcophagus was successfully rewrapped',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const rewrapFailure = (): UseToastOptions => ({
   title: 'Rewrap Failed.',
   description: 'Your sarcophagus was not rewrapped',
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const burySuccess = (): UseToastOptions => ({
   title: 'Bury Successful.',
   description: 'Your sarcophagus was buried successfully',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const buryFailure = (): UseToastOptions => ({
   title: 'Bury Failed.',
   description: 'Your sarcophagus was not buried',
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const cleanSuccess = (): UseToastOptions => ({
   title: 'Clean Successful.',
   description: 'Your sarcophagus was cleaned successfully',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const cleanFailure = (): UseToastOptions => ({
   title: 'Clean Failed.',
   description: 'The sarcophagus was not cleaned',
   status: 'error',
-  duration,
-  position,
+  ...defaultOptions,
 });
 
 export const publicKeyRetrieved = (): UseToastOptions => ({
   title: 'Public key successfully retrieved!',
   status: 'success',
-  duration,
-  position,
+  ...defaultOptions,
 });

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -30,6 +30,8 @@ export const colors = {
     700: '#343A40',
     800: '#2A3036',
     900: '#20262D',
+    950: '#1c1e21',
+    1000: '#131416',
   },
 
   // Bright colors typically used for toasts and alerts
@@ -40,7 +42,15 @@ export const colors = {
   yellow: '#FFF72D',
   gray: '#8c8c8c',
 
-  // Transparent versions of the bright colors typically used for backgrounds
+  background: {
+    blue: '#031526',
+    green: '#031E0B',
+    orange: '#261807',
+    red: '#250A0A',
+    yellow: '#262507',
+    gray: '#151515',
+  },
+
   transparent: {
     blue: '#168FFF26',
     green: '#17CB4926',
@@ -50,39 +60,9 @@ export const colors = {
     gray: '#8c8c8c26',
   },
 
-  // alert components
-  alert: {
-    info: '#168FFF',
-    infoBackground: '#168FFF26',
-    success: '#17CB49',
-    successBackground: '#17CB4926',
-    warning: '#FF9F2D',
-    warningBackground: '#FF9F2D26',
-    error: '#F74141',
-    errorBackground: '#F7414126',
-  },
-
-  table: {
-    textBackground: '#383a4066',
-    errorBackground: '#F7414126',
-  },
-
   text: {
     primary: '#FFFFFF', // brand.950
     secondary: '#a6a6a6', // brand.600
     disabled: '#737373', // brand.400
-  },
-
-  checkboxScheme: {
-    500: '#168FFF',
-  },
-
-  //TODO, items from oldColors to be resolved and whitAlpha is still being used in places
-  errorHighlight: '#F7414126',
-  errorAlt: '#290e0e',
-
-  menuBlue: {
-    700: '#343A40',
-    1000: '#131416',
   },
 };

--- a/src/theme/components/Alert.ts
+++ b/src/theme/components/Alert.ts
@@ -1,23 +1,12 @@
-import { defineStyle, createMultiStyleConfigHelpers } from '@chakra-ui/styled-system';
+import { alertAnatomy } from '@chakra-ui/anatomy';
 import { AlertProps } from '@chakra-ui/react';
+import { createMultiStyleConfigHelpers } from '@chakra-ui/styled-system';
 
-const helpers = createMultiStyleConfigHelpers([
-  'container',
-  'title',
-  'description',
-  'icon',
-  'spinner',
-]);
+const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(
+  alertAnatomy.keys
+);
 
-/*
-NOTE regarding the icon color: we should be able to set the styles on icon:{} part, but the current
- implmentation of <Alert> in the chakra library utilizes "colorScheme"
-  in the alert component to pass down the status color to the icon.
-   therefore we have to set our own icon and color on our custom component.
-    see : chakra-ui\packages\components\alert\src\alert.tsx line: 44 
-    where they retrieve the style "const styles = useMultiStyleConfig("Alert", { ...props, colorScheme })"
-*/
-const titleAndDescriptionStyle = defineStyle({
+const titleAndDescriptionStyle = definePartsStyle({
   title: {
     color: 'brand.950',
     fontSize: '16px',
@@ -27,6 +16,7 @@ const titleAndDescriptionStyle = defineStyle({
   description: {
     color: 'brand.950',
     lineHeight: '1',
+    marginTop: '8px',
   },
 });
 
@@ -34,34 +24,54 @@ const alertStatusStyles: { [key: string]: any } = {
   success: {
     container: {
       bg: 'unset',
-      backgroundColor: 'alert.successBackground',
+      backgroundColor: 'background.green',
+      borderLeft: '4px solid',
+      borderColor: 'green',
+    },
+    icon: {
+      color: 'green',
     },
     ...titleAndDescriptionStyle,
   },
   info: {
     container: {
       bg: 'unset',
-      backgroundColor: 'alert.infoBackground',
+      backgroundColor: 'background.blue',
+      borderLeft: '4px solid',
+      borderColor: 'blue',
+    },
+    icon: {
+      color: 'blue',
     },
     ...titleAndDescriptionStyle,
   },
   warning: {
     container: {
       bg: 'unset',
-      backgroundColor: 'alert.warningBackground',
+      backgroundColor: 'background.orange',
+      borderLeft: '4px solid',
+      borderColor: 'orange',
+    },
+    icon: {
+      color: 'orange',
     },
     ...titleAndDescriptionStyle,
   },
   error: {
     container: {
       bg: 'unset',
-      backgroundColor: 'alert.errorBackground',
+      backgroundColor: 'background.red',
+      borderLeft: '4px solid',
+      borderColor: 'red',
+    },
+    icon: {
+      color: 'red',
     },
     ...titleAndDescriptionStyle,
   },
 };
 
-export const Alert = helpers.defineMultiStyleConfig({
+export const Alert = defineMultiStyleConfig({
   baseStyle: (props: AlertProps) => alertStatusStyles[props.status || 'default'],
   sizes: {},
   variants: {},

--- a/src/theme/components/Checkbox.ts
+++ b/src/theme/components/Checkbox.ts
@@ -1,0 +1,44 @@
+import { checkboxAnatomy } from '@chakra-ui/anatomy';
+import { createMultiStyleConfigHelpers } from '@chakra-ui/styled-system';
+
+const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(
+  checkboxAnatomy.keys
+);
+
+const blue = definePartsStyle({
+  control: {
+    borderRadius: 0,
+    _checked: {
+      bg: 'blue',
+      borderColor: 'blue',
+      _hover: {
+        bg: 'blue',
+        borderColor: 'blue',
+      },
+    },
+  },
+});
+
+const brand = definePartsStyle({
+  control: {
+    borderRadius: 0,
+    _checked: {
+      bg: 'brand.500',
+      borderColor: 'brand.500',
+      _hover: {
+        bg: 'brand.500',
+        borderColor: 'brand.500',
+      },
+    },
+  },
+});
+
+export const Checkbox = defineMultiStyleConfig({
+  baseStyle: blue,
+  sizes: {},
+  variants: {
+    blue,
+    brand,
+  },
+  defaultProps: {},
+});

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,5 +1,6 @@
 import { Alert } from './Alert';
 import { Button } from './Button';
+import { Checkbox } from './Checkbox';
 import { Divider } from './Divider';
 import { FormLabel } from './FormLabel';
 import { Heading } from './Heading';
@@ -18,5 +19,6 @@ export const components = {
   Divider,
   Alert,
   Tooltip,
+  Checkbox,
   Textarea,
 };

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -4,6 +4,10 @@ export const styles = {
       bg: 'brand.0',
       color: 'brand.950',
       fontSize: '14px',
+      // Required to make the toast corners square
+      '.chakra-alert': {
+        borderRadius: 0,
+      },
     },
   },
 };


### PR DESCRIPTION
Here is another option for restyling toasts that uses the chakra theme instead of creating a new toast hook. 

Also modified colors in various places while I was messing with the color palette. There were some things that were named like `tableText` and `alert` but I removed those and kept just the names of the colors. It's a good idea to name these things but it will take some time and we will need to put more thought into it. 

![image](https://user-images.githubusercontent.com/34484576/205998908-ca19e10a-fd16-408e-9329-71396b012e44.png)
