### PR TITLE
Claim button on detail page visible to any address

### DIFF
--- a/src/features/sarcophagi/components/Details.tsx
+++ b/src/features/sarcophagi/components/Details.tsx
@@ -22,8 +22,7 @@ export function Details() {
     sarcophagus?.state === SarcophagusState.Active && sarcophagus?.embalmerAddress === address;
 
   // Determine if the claim function is available
-  const canClaim =
-    sarcophagus?.state === SarcophagusState.Resurrected && sarcophagus.recipientAddress === address;
+  const canClaim = sarcophagus?.state === SarcophagusState.Resurrected;
 
   return (
     <Flex direction="column">


### PR DESCRIPTION
### Overview

The "claim" button on the details page, once the sarco has resurrected, shows to any address, not just the recipient.

Below my address on the top right is not the recipient, yet I can see the claim button:
![Sarcophagus Name](https://user-images.githubusercontent.com/105349716/206116778-4b1144d4-83aa-4a49-b1ed-da2370c0d0f7.png)
