### PR TITLE
Bundlr Chunked Uploader

### DIFF
--- a/src/features/embalm/stepContent/hooks/useBundlr.ts
+++ b/src/features/embalm/stepContent/hooks/useBundlr.ts
@@ -1,6 +1,8 @@
 import { useToast } from '@chakra-ui/react';
+import { AxiosResponse } from 'axios';
 import { BigNumber, ethers } from 'ethers';
 import { formatEther } from 'ethers/lib/utils';
+import { chunkedUploaderFileSize } from 'lib/constants';
 import {
   fundStart,
   fundSuccess,
@@ -93,7 +95,18 @@ export function useBundlr() {
 
       toast(uploadStart());
       try {
-        const res = await bundlr?.upload(fileBuffer);
+        let res;
+
+        if (Buffer.byteLength(fileBuffer) < chunkedUploaderFileSize) {
+          console.log('bundlr?.upload');
+          res = await bundlr?.upload(fileBuffer);
+        } else {
+          console.log('chunkedUploader');
+          const uploader = bundlr?.uploader.chunkedUploader;
+          res = await uploader?.uploadData(fileBuffer);
+        }
+
+        console.log('upload success');
         toast(uploadSuccess());
         return res.data.id;
       } catch (_error) {

--- a/src/features/embalm/stepContent/hooks/useBundlr.ts
+++ b/src/features/embalm/stepContent/hooks/useBundlr.ts
@@ -1,5 +1,4 @@
 import { useToast } from '@chakra-ui/react';
-import { AxiosResponse } from 'axios';
 import { BigNumber, ethers } from 'ethers';
 import { formatEther } from 'ethers/lib/utils';
 import { chunkedUploaderFileSize } from 'lib/constants';
@@ -98,15 +97,12 @@ export function useBundlr() {
         let res;
 
         if (Buffer.byteLength(fileBuffer) < chunkedUploaderFileSize) {
-          console.log('bundlr?.upload');
           res = await bundlr?.upload(fileBuffer);
         } else {
-          console.log('chunkedUploader');
           const uploader = bundlr?.uploader.chunkedUploader;
           res = await uploader?.uploadData(fileBuffer);
         }
 
-        console.log('upload success');
         toast(uploadSuccess());
         return res.data.id;
       } catch (_error) {

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadDoubleEncryptedFile.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadDoubleEncryptedFile.ts
@@ -18,23 +18,15 @@ export function useUploadDoubleEncryptedFile() {
       };
 
       // Step 1: Encrypt the inner layer
-      console.log('step 1');
-      console.log('recipientState.publicKey', recipientState.publicKey);
-      console.log('JSON.stringify(payload))', JSON.stringify(payload));
-      console.log('Buffer.from(JSON.stringify(payload))', Buffer.from(JSON.stringify(payload)));
-
       const encryptedInnerLayer = await encrypt(
         recipientState.publicKey,
-        Buffer.from(JSON.stringify(payload))
+        Buffer.from(JSON.stringify(payload), 'hex')
       );
 
-      console.log(' encryptedInnerLayer complete');
       // Step 2: Encrypt the outer layer
-      console.log('step 2');
       const encryptedOuterLayer = await encrypt(outerPublicKey!, encryptedInnerLayer);
 
       // Step 3: Upload the double encrypted payload to arweave
-      console.log('step 3');
       const payloadTxId = await uploadToArweave(encryptedOuterLayer);
 
       setSarcophagusPayloadTxId(payloadTxId);

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadDoubleEncryptedFile.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadDoubleEncryptedFile.ts
@@ -18,15 +18,23 @@ export function useUploadDoubleEncryptedFile() {
       };
 
       // Step 1: Encrypt the inner layer
+      console.log('step 1');
+      console.log('recipientState.publicKey', recipientState.publicKey);
+      console.log('JSON.stringify(payload))', JSON.stringify(payload));
+      console.log('Buffer.from(JSON.stringify(payload))', Buffer.from(JSON.stringify(payload)));
+
       const encryptedInnerLayer = await encrypt(
         recipientState.publicKey,
         Buffer.from(JSON.stringify(payload))
       );
 
+      console.log(' encryptedInnerLayer complete');
       // Step 2: Encrypt the outer layer
+      console.log('step 2');
       const encryptedOuterLayer = await encrypt(outerPublicKey!, encryptedInnerLayer);
 
       // Step 3: Upload the double encrypted payload to arweave
+      console.log('step 3');
       const payloadTxId = await uploadToArweave(encryptedOuterLayer);
 
       setSarcophagusPayloadTxId(payloadTxId);

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -1,5 +1,6 @@
 export const maxSarcophagusNameLength = 60;
 export const maxFileSize = 200 * 1000 * 1000;
+export const chunkedUploaderFileSize = 50 * 1000 * 1000;
 export const bundlrBalanceDecimals = 8;
 export const uploadPriceDecimals = 8;
 export const minimumResurrection = 30_000;


### PR DESCRIPTION
### Overview

If user uploaded file is >=50MB, Bundlr uses "chunked" uploading.

Had to change the Buffer.from encoding to hex for the app not to crash.

Tested upload with file up to 150MB

