### PR TITLE
add isOnline check via dialing

### DIFF
--- a/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
@@ -123,7 +123,7 @@ export function ArchaeologistListItem({
         <Td>
           <Button
             disabled={isDialing || !!archaeologist.connection}
-            onClick={() => testDialArchaeologist(archaeologist.fullPeerId!)}
+            onClick={() => testDialArchaeologist(archaeologist, true)}
           >
             {archaeologist.connection ? 'Connected' : 'Dial'}
           </Button>

--- a/src/features/embalm/stepContent/hooks/useLoadArchaeologists.ts
+++ b/src/features/embalm/stepContent/hooks/useLoadArchaeologists.ts
@@ -6,6 +6,7 @@ import { setArchaeologists, setCurrentChainId } from 'store/embalm/actions';
 import { useDispatch, useSelector } from 'store/index';
 import { useNetwork } from 'wagmi';
 import { readContract } from 'wagmi/actions';
+import { useAttemptDialArchaeologists } from '../../../../hooks/utils/useAttemptDialArchaeologists';
 
 /**
  * Loads archaeologist profiles from the sarcophagus contract
@@ -15,6 +16,7 @@ export function useLoadArchaeologists() {
   const networkConfig = useNetworkConfig();
   const { archaeologists, currentChainId } = useSelector(s => s.embalmState);
   const { chain } = useNetwork();
+  const { testDialArchaeologist } = useAttemptDialArchaeologists();
 
   const getProfiles = useCallback(async () => {
     if (!networkConfig.diamondDeployAddress) {
@@ -43,7 +45,7 @@ export function useLoadArchaeologists() {
       args: [addresses],
     })) as any[];
 
-    return profiles.map((p, i) => ({
+    const discoveredArchaeologists = profiles.map((p, i) => ({
       profile: {
         ...p,
         archAddress: addresses[i],
@@ -54,9 +56,20 @@ export function useLoadArchaeologists() {
       },
       // TODO - temporarily list all archs that have domains as online
       // until discovery for archs using websockets is updated
-      isOnline: p.peerId.includes(':'),
+      isOnline: false,
     }));
-  }, [networkConfig.diamondDeployAddress]);
+
+    for (let arch of discoveredArchaeologists) {
+      console.log('inside');
+      if (arch.profile.peerId.includes(':')) {
+        console.log('dialing arch');
+        arch.isOnline = await testDialArchaeologist(arch);
+        console.log(arch.isOnline);
+      }
+    }
+
+    return discoveredArchaeologists;
+  }, [networkConfig.diamondDeployAddress, testDialArchaeologist]);
 
   useEffect(() => {
     (async () => {

--- a/src/features/embalm/stepContent/hooks/useLoadArchaeologists.ts
+++ b/src/features/embalm/stepContent/hooks/useLoadArchaeologists.ts
@@ -54,17 +54,14 @@ export function useLoadArchaeologists() {
         accusals: stats[i].accusals,
         failures: stats[i].failures,
       },
-      // TODO - temporarily list all archs that have domains as online
-      // until discovery for archs using websockets is updated
       isOnline: false,
     }));
 
     for (let arch of discoveredArchaeologists) {
-      console.log('inside');
+      // if arch profile has the delimiter, it has a domain
+      // attempt to dial this archaeologist to confirm it is online
       if (arch.profile.peerId.includes(':')) {
-        console.log('dialing arch');
         arch.isOnline = await testDialArchaeologist(arch);
-        console.log(arch.isOnline);
       }
     }
 

--- a/src/hooks/utils/useAttemptDialArchaeologists.ts
+++ b/src/hooks/utils/useAttemptDialArchaeologists.ts
@@ -14,7 +14,11 @@ export function useAttemptDialArchaeologists(
   // Dials the archaeologist and hangs up after an interval
   // sets dial status for use in the UX
   const testDialArchaeologist = useCallback(
-    async (arch: Archaeologist, showToast: boolean = false, hangUpInterval: number = 200): Promise<boolean> => {
+    async (
+      arch: Archaeologist,
+      showToast: boolean = false,
+      hangUpInterval: number = 200
+    ): Promise<boolean> => {
       if (!libp2pNode) {
         return false;
       }

--- a/src/hooks/utils/useAttemptDialArchaeologists.ts
+++ b/src/hooks/utils/useAttemptDialArchaeologists.ts
@@ -2,11 +2,11 @@ import React, { useCallback } from 'react';
 import { useSelector } from '../../store';
 import { useToast } from '@chakra-ui/react';
 import { dialArchaeologistFailure, dialArchaeologistSuccess } from '../../lib/utils/toast';
-import { PeerId } from '@libp2p/interface-peer-id';
 import { Multiaddr, multiaddr } from '@multiformats/multiaddr';
+import { Archaeologist } from '../../types';
 
 export function useAttemptDialArchaeologists(
-  setIsDialing: React.Dispatch<React.SetStateAction<boolean>>
+  setIsDialing?: React.Dispatch<React.SetStateAction<boolean>>
 ) {
   const libp2pNode = useSelector(s => s.appState.libp2pNode);
   const toast = useToast();
@@ -14,36 +14,49 @@ export function useAttemptDialArchaeologists(
   // Dials the archaeologist and hangs up after an interval
   // sets dial status for use in the UX
   const testDialArchaeologist = useCallback(
-    async (peerId: PeerId, hangUpInterval: number = 2000) => {
+    async (arch: Archaeologist, showToast: boolean = false, hangUpInterval: number = 200): Promise<boolean> => {
       if (!libp2pNode) {
-        return;
+        return false;
       }
 
       try {
         let ma: Multiaddr;
-        setIsDialing(true);
-        // TODO -- this ma code can be removed/updated once testing on this single arch is complete.
-        if (!peerId) {
-          ma = multiaddr(
-            '/dns4/wss.encryptafile.com/tcp/443/wss/p2p/12D3KooWPLcrUEMREHW3eT6EWTTbgaKFeay8Ywqck7dyVSERfJZd'
-          );
-          console.log(ma.getPeerId());
+
+        if (!!setIsDialing) {
+          setIsDialing(true);
+        }
+
+        const peerIdParsed = arch.profile.peerId.split(':');
+        if (peerIdParsed.length === 2) {
+          ma = multiaddr(`/dns4/${peerIdParsed[0]}/tcp/443/wss/p2p/${peerIdParsed[1]}`);
           // @ts-ignore
           await libp2pNode.dial(ma);
         } else {
-          console.log(peerId.multihash);
-          await libp2pNode.dial(peerId);
+          await libp2pNode.dial(arch.fullPeerId!);
         }
-        toast(dialArchaeologistSuccess());
+
+        if (showToast) {
+          toast(dialArchaeologistSuccess());
+        }
+
         setTimeout(async () => {
           // @ts-ignore
           await libp2pNode?.hangUp(ma || peerId);
         }, hangUpInterval);
+
+        return true;
       } catch (error) {
         console.log(error);
-        toast(dialArchaeologistFailure());
+
+        if (showToast) {
+          toast(dialArchaeologistFailure());
+        }
+
+        return false;
       } finally {
-        setIsDialing(false);
+        if (!!setIsDialing) {
+          setIsDialing(false);
+        }
       }
     },
     [libp2pNode, setIsDialing, toast]


### PR DESCRIPTION
## Overview
1. Dial archaeologists that are registered with a domain to determine if they are online.
2. Peer discovery is still turned on if using star signalling server

## TODO
Look into converting from dialing archs to using peer discovery via bootstrap nodes (this method should scale better). The arch service is already setup to use bootstrap nodes.