### PR TITLE
reduce node timeout

### DIFF
--- a/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
+++ b/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
@@ -9,8 +9,6 @@ import { constants, ethers, BigNumber } from 'ethers';
 import { filterSplit } from 'lib/utils/helpers';
 
 export function useArchaeologistList() {
-  useLoadArchaeologists();
-
   const dispatch = useDispatch();
 
   const { archaeologists, selectedArchaeologists } = useSelector(s => s.embalmState);

--- a/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
+++ b/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
@@ -3,7 +3,6 @@ import { deselectArchaeologist, selectArchaeologist } from 'store/embalm/actions
 import { SortDirection, SortFilterType, setSortDirection } from 'store/archaeologistList/actions';
 import { useDispatch, useSelector } from 'store/index';
 import { Archaeologist } from 'types/index';
-import { useLoadArchaeologists } from './useLoadArchaeologists';
 import { orderBy, keys } from 'lodash';
 import { constants, ethers, BigNumber } from 'ethers';
 import { filterSplit } from 'lib/utils/helpers';

--- a/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
+++ b/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
@@ -19,7 +19,7 @@ import { ChevronLeftIcon, ChevronRightIcon, QuestionIcon } from '@chakra-ui/icon
 import { SetResurrection } from '../components/SetResurrection';
 import { useSelector } from 'store/index';
 import moment from 'moment';
-import { useLoadArchaeologists } from "../hooks/useLoadArchaeologists";
+import { useLoadArchaeologists } from '../hooks/useLoadArchaeologists';
 
 export function SelectArchaeologists({
   hideHeader = false,

--- a/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
+++ b/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
@@ -19,6 +19,7 @@ import { ChevronLeftIcon, ChevronRightIcon, QuestionIcon } from '@chakra-ui/icon
 import { SetResurrection } from '../components/SetResurrection';
 import { useSelector } from 'store/index';
 import moment from 'moment';
+import { useLoadArchaeologists } from "../hooks/useLoadArchaeologists";
 
 export function SelectArchaeologists({
   hideHeader = false,
@@ -29,6 +30,10 @@ export function SelectArchaeologists({
 }) {
   const outerLimit = 1;
   const innerLimit = 1;
+
+  // Load the archaeologists' data
+  useLoadArchaeologists();
+
   const { sortedFilteredArchaeologist, showSelectedArchaeologists, hiddenArchaeologists } =
     useArchaeologistList();
   const { resurrection } = useSelector(x => x.embalmState);

--- a/src/lib/config/node_config.ts
+++ b/src/lib/config/node_config.ts
@@ -43,6 +43,6 @@ export const nodeConfig: any = {
   dht,
   connectionManager: {
     autoDial: false,
-    dialTimeout: 5000,
+    dialTimeout: 2000,
   },
 };


### PR DESCRIPTION
## Overview
Reduce timeout on dialing archaeologists to 2 seconds from 5 seconds. This was done to decrease load time of archaeologists.

Archaeologists were also being dialed twice for discovery -- changed location of `useLoadArchaeologists` so that they are only dialed once.