### PR TITLE
Max res time UX

### DIFF
--- a/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
@@ -84,7 +84,7 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
                 variant="bold"
                 as="u"
               >
-                {formatSarco(diggingFees)} SARCO
+                {formatSarco(diggingFees.toString())} SARCO
               </Text>
             </Text>
             <Text

--- a/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
@@ -20,10 +20,10 @@ interface ResetPage {
 export function ArchaeologistHeader({ resetPage }: ResetPage) {
   const dispatch = useDispatch();
   const { selectedArchaeologists } = useSelector(x => x.embalmState);
-  const { showSelectedArchaeologists } = useSelector(x => x.archaeologistListState);
+  const { showOnlySelectedArchaeologists } = useSelector(x => x.archaeologistListState);
 
-  function selectAndReset() {
-    dispatch(setShowSelectedArchaeologists(!showSelectedArchaeologists));
+  function toggleShowOnlySelected() {
+    dispatch(setShowSelectedArchaeologists(!showOnlySelectedArchaeologists));
     resetPage(1);
   }
 
@@ -42,7 +42,7 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
           <HStack direction="row">
             <Checkbox
               variant="brand"
-              onChange={() => selectAndReset()}
+              onChange={() => toggleShowOnlySelected()}
             />
             <HStack>
               <Text>

--- a/src/features/embalm/stepContent/components/ArchaeologistList.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistList.tsx
@@ -45,7 +45,7 @@ export function ArchaeologistList({
     archAddressSearch,
     unwrapsFilter,
     failsFilter,
-    showSelectedArchaeologists: onlyShowSelected,
+    showOnlySelectedArchaeologists,
   } = useArchaeologistList();
 
   const sortIconsMap: { [key: number]: JSX.Element } = {
@@ -93,7 +93,8 @@ export function ArchaeologistList({
                         color="text.primary"
                         p={'0.5'}
                       >
-                        Archaeologists ({getArchaeologistListToShow({ onlyShowSelected })?.length})
+                        Archaeologists (
+                        {getArchaeologistListToShow({ showOnlySelectedArchaeologists })?.length})
                       </Button>
                       <FilterInput
                         filterName={SortFilterType.ADDRESS_SEARCH}

--- a/src/features/embalm/stepContent/components/ArchaeologistList.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistList.tsx
@@ -35,7 +35,7 @@ export function ArchaeologistList({
   const {
     handleCheckArchaeologist,
     selectedArchaeologists,
-    getArchaeologistListToShow,
+    archaeologistListVisible,
     onClickSortDiggingFees,
     onClickSortUnwraps,
     onClickSortFails,
@@ -45,8 +45,6 @@ export function ArchaeologistList({
     archAddressSearch,
     unwrapsFilter,
     failsFilter,
-    showOnlySelectedArchaeologists,
-    showHiddenArchaeologists,
   } = useArchaeologistList();
 
   const sortIconsMap: { [key: number]: JSX.Element } = {
@@ -94,14 +92,7 @@ export function ArchaeologistList({
                         color="text.primary"
                         p={'0.5'}
                       >
-                        Archaeologists (
-                        {
-                          getArchaeologistListToShow({
-                            showOnlySelectedArchaeologists,
-                            includeHidden: showHiddenArchaeologists,
-                          })?.length
-                        }
-                        )
+                        Archaeologists ({archaeologistListVisible()?.length})
                       </Button>
                       <FilterInput
                         filterName={SortFilterType.ADDRESS_SEARCH}
@@ -198,7 +189,7 @@ export function ArchaeologistList({
                       key={arch.profile.archAddress}
                       archaeologist={arch}
                       onClick={() => {
-                        if (showDial) return;
+                        if (showDial || arch.hiddenReason) return;
                         handleCheckArchaeologist(arch);
                       }}
                       includeDialButton={showDial!}

--- a/src/features/embalm/stepContent/components/ArchaeologistList.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistList.tsx
@@ -18,12 +18,13 @@ import { QuestionIcon } from '@chakra-ui/icons';
 import { DownIcon, UpDownIcon, UpIcon } from 'components/icons';
 import { Loading } from 'components/Loading';
 import { useArchaeologistList } from '../hooks/useArchaeologistList';
-import { SortDirection } from 'store/embalm/actions';
+import { deselectArchaeologist, SortDirection } from 'store/embalm/actions';
 import { SortFilterType } from 'store/archaeologistList/actions';
 import { FilterInput } from './FilterInput';
 import { useState } from 'react';
 import { useBootLibp2pNode } from '../../../../hooks/libp2p/useBootLibp2pNode';
 import { ArchaeologistListItem } from './ArchaeologistListItem';
+import { useDispatch } from 'store/index';
 
 export function ArchaeologistList({
   showDial,
@@ -35,6 +36,7 @@ export function ArchaeologistList({
   const {
     handleCheckArchaeologist,
     selectedArchaeologists,
+    hiddenArchaeologists,
     archaeologistListVisible,
     onClickSortDiggingFees,
     onClickSortUnwraps,
@@ -63,6 +65,14 @@ export function ArchaeologistList({
       ? sortIconsMap[archaeologistFilterSort.sortDirection]
       : sortIconsMap[SortDirection.NONE];
   }
+
+  const dispatch = useDispatch();
+
+  hiddenArchaeologists.map(a => {
+    if (selectedArchaeologists.includes(a)) {
+      dispatch(deselectArchaeologist(a.profile.archAddress));
+    }
+  });
 
   return (
     <Flex

--- a/src/features/embalm/stepContent/components/ArchaeologistList.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistList.tsx
@@ -46,6 +46,7 @@ export function ArchaeologistList({
     unwrapsFilter,
     failsFilter,
     showOnlySelectedArchaeologists,
+    showHiddenArchaeologists,
   } = useArchaeologistList();
 
   const sortIconsMap: { [key: number]: JSX.Element } = {
@@ -94,7 +95,13 @@ export function ArchaeologistList({
                         p={'0.5'}
                       >
                         Archaeologists (
-                        {getArchaeologistListToShow({ showOnlySelectedArchaeologists })?.length})
+                        {
+                          getArchaeologistListToShow({
+                            showOnlySelectedArchaeologists,
+                            includeHidden: showHiddenArchaeologists,
+                          })?.length
+                        }
+                        )
                       </Button>
                       <FilterInput
                         filterName={SortFilterType.ADDRESS_SEARCH}

--- a/src/features/embalm/stepContent/components/ArchaeologistList.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistList.tsx
@@ -35,7 +35,7 @@ export function ArchaeologistList({
   const {
     handleCheckArchaeologist,
     selectedArchaeologists,
-    sortedFilteredArchaeologist,
+    getArchaeologistListToShow,
     onClickSortDiggingFees,
     onClickSortUnwraps,
     onClickSortFails,
@@ -45,7 +45,7 @@ export function ArchaeologistList({
     archAddressSearch,
     unwrapsFilter,
     failsFilter,
-    showSelectedArchaeologists,
+    showSelectedArchaeologists: onlyShowSelected,
   } = useArchaeologistList();
 
   const sortIconsMap: { [key: number]: JSX.Element } = {
@@ -93,8 +93,7 @@ export function ArchaeologistList({
                         color="text.primary"
                         p={'0.5'}
                       >
-                        Archaeologists (
-                        {sortedFilteredArchaeologist(showSelectedArchaeologists)?.length})
+                        Archaeologists ({getArchaeologistListToShow({ onlyShowSelected })?.length})
                       </Button>
                       <FilterInput
                         filterName={SortFilterType.ADDRESS_SEARCH}

--- a/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
@@ -1,4 +1,4 @@
-import { Flex, Td, Text, Tr, Button, Checkbox } from '@chakra-ui/react';
+import { Flex, Td, Text, Tr, Button, Checkbox, Tooltip } from '@chakra-ui/react';
 import { Archaeologist } from '../../../../types/index';
 import { formatAddress } from 'lib/utils/helpers';
 import { selectArchaeologist, deselectArchaeologist } from 'store/embalm/actions';
@@ -69,7 +69,7 @@ export function ArchaeologistListItem({
           )}
           <Text
             ml={3}
-            bg={'grayBlue.950'}
+            bg={archaeologist.hiddenReason ? 'transparent.red' : 'grayBlue.950'}
             color={rowTextColor}
             py={0.5}
             px={2}
@@ -87,57 +87,64 @@ export function ArchaeologistListItem({
   };
 
   return (
-    <Tr
-      background={isSelected ? (archaeologist.exception ? 'background.red' : 'brand.50') : ''}
-      onClick={() => handleClickRow()}
-      cursor="pointer"
-      _hover={isSelected ? {} : { background: 'brand.0' }}
+
+    <Tooltip
+      label={archaeologist.hiddenReason}
+      placement="top"
     >
-      <TableContent
-        icon={false}
-        checkbox={true}
+      <Tr
+        background={isSelected ? (archaeologist.exception || archaeologist.hiddenReason ? 'background.red' : 'brand.50') : ''}
+        onClick={() => handleClickRow()}
+        cursor="pointer"
+        _hover={isSelected ? {} : { background: 'brand.0' }}
       >
-        {formattedArchAddress()}
-      </TableContent>
+        <TableContent
+          icon={false}
+          checkbox={true}
+        >
+          {formattedArchAddress()}
+        </TableContent>
 
-      <TableContent
-        icon={true}
-        checkbox={false}
-      >
-        {/* TODO: this shows monthly values. will need to be updated to show actual digging fees based on resurrection time */}
-        {/* We may want to show the monthly values on the "archaeologists" page */}
-        {Number(
-          ethers.utils.formatEther(archaeologist.profile.minimumDiggingFeePerSecond.mul(2628288))
-        )
-          .toFixed(2)
-          .toString()
-          .concat(' SARCO/month')}
-      </TableContent>
-      <TableContent
-        icon={false}
-        checkbox={false}
-      >
-        {archaeologist.profile.successes.toString()}
-      </TableContent>
-      <TableContent
-        icon={false}
-        checkbox={false}
-      >
-        {archaeologist.profile.failures.toString()}
-      </TableContent>
+        <TableContent
+          icon={true}
+          checkbox={false}
+        >
+          {/* TODO: this shows monthly values. will need to be updated to show actual digging fees based on resurrection time */}
+          {/* We may want to show the monthly values on the "archaeologists" page */}
+          {Number(
+            ethers.utils.formatEther(archaeologist.profile.minimumDiggingFeePerSecond.mul(2628288))
+          )
+            .toFixed(2)
+            .toString()
+            .concat(' SARCO/month')}
+        </TableContent>
+        <TableContent
+          icon={false}
+          checkbox={false}
+        >
+          {archaeologist.profile.successes.toString()}
+        </TableContent>
+        <TableContent
+          icon={false}
+          checkbox={false}
+        >
+          {archaeologist.profile.failures.toString()}
+        </TableContent>
 
-      {includeDialButton ? (
-        <Td>
-          <Button
-            disabled={isDialing || !!archaeologist.connection}
-            onClick={() => testDialArchaeologist(archaeologist, true)}
-          >
-            {archaeologist.connection ? 'Connected' : 'Dial'}
-          </Button>
-        </Td>
-      ) : (
-        <></>
-      )}
-    </Tr>
+        {includeDialButton ? (
+          <Td>
+            <Button
+              disabled={isDialing || !!archaeologist.connection}
+              onClick={() => testDialArchaeologist(archaeologist, true)}
+            >
+              {archaeologist.connection ? 'Connected' : 'Dial'}
+            </Button>
+          </Td>
+        ) : (
+          <></>
+        )}
+      </Tr>
+
+    </Tooltip>
   );
 }

--- a/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
@@ -1,4 +1,4 @@
-import { Flex, Td, Text, Tr, Button, Checkbox, Tooltip } from '@chakra-ui/react';
+import { Flex, Td, Text, Tr, Button, Checkbox, Tooltip, Box } from '@chakra-ui/react';
 import { Archaeologist } from '../../../../types/index';
 import { formatAddress } from 'lib/utils/helpers';
 import { selectArchaeologist, deselectArchaeologist } from 'store/embalm/actions';
@@ -23,6 +23,7 @@ interface TableContentProps {
   children: React.ReactNode;
   icon: boolean;
   checkbox: boolean;
+  align?: string;
 }
 
 export function ArchaeologistListItem({
@@ -47,13 +48,13 @@ export function ArchaeologistListItem({
     return ensName ?? formatAddress(archaeologist.profile.archAddress);
   };
 
-  function TableContent({ children, icon, checkbox }: TableContentProps) {
+  function TableContent({ children, icon, checkbox, align }: TableContentProps) {
     return (
       <Td
         borderBottom="none"
         isNumeric
       >
-        <Flex justify={icon || checkbox ? 'left' : 'center'}>
+        <Flex justify={align || (icon || checkbox ? 'left' : 'center')}>
           {icon && <SarcoTokenIcon boxSize="18px" />}
           {checkbox && (
             <Checkbox
@@ -65,8 +66,9 @@ export function ArchaeologistListItem({
                   dispatch(deselectArchaeologist(archaeologist.profile.archAddress));
                 }
               }}
-            ></Checkbox>
+            />
           )}
+          <Box width={!icon && !checkbox ? '4' : '0'} />
           <Text
             ml={3}
             bg={archaeologist.hiddenReason ? 'transparent.red' : 'grayBlue.950'}
@@ -101,7 +103,8 @@ export function ArchaeologistListItem({
       >
         <TableContent
           icon={false}
-          checkbox={true}
+          checkbox={!archaeologist.hiddenReason}
+          align="left"
         >
           {formattedArchAddress()}
         </TableContent>

--- a/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
@@ -38,13 +38,13 @@ export function ArchaeologistListItem({
   const networkConfig = useNetworkConfig();
   const rowTextColor = isSelected ? (archaeologist.exception ? '' : 'brand.950') : '';
 
-  const { data } = useEnsName({
+  const { data: ensName } = useEnsName({
     address: archaeologist.profile.archAddress as `0x${string}`,
     chainId: networkConfig.chainId,
   });
 
   const formattedArchAddress = () => {
-    return data ?? formatAddress(archaeologist.profile.archAddress);
+    return ensName ?? formatAddress(archaeologist.profile.archAddress);
   };
 
   function TableContent({ children, icon, checkbox }: TableContentProps) {

--- a/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
@@ -31,7 +31,7 @@ export function ArchaeologistListItem({
   includeDialButton,
   isDialing,
   setIsDialing,
-  onClick,
+  onClick: handleClickRow,
 }: ArchaeologistListItemProps) {
   const { testDialArchaeologist } = useAttemptDialArchaeologists(setIsDialing);
   const dispatch = useDispatch();
@@ -82,18 +82,19 @@ export function ArchaeologistListItem({
     );
   }
 
-  const handleClickRow = () => {
-    onClick();
-  };
-
   return (
-
     <Tooltip
       label={archaeologist.hiddenReason}
       placement="top"
     >
       <Tr
-        background={isSelected ? (archaeologist.exception || archaeologist.hiddenReason ? 'background.red' : 'brand.50') : ''}
+        background={
+          isSelected
+            ? archaeologist.exception || archaeologist.hiddenReason
+              ? 'background.red'
+              : 'brand.50'
+            : ''
+        }
         onClick={() => handleClickRow()}
         cursor="pointer"
         _hover={isSelected ? {} : { background: 'brand.0' }}
@@ -144,7 +145,6 @@ export function ArchaeologistListItem({
           <></>
         )}
       </Tr>
-
     </Tooltip>
   );
 }

--- a/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
+++ b/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
@@ -1,9 +1,8 @@
 import { InfoOutlineIcon } from '@chakra-ui/icons';
 import { Box, Divider, Flex, Text, Tooltip } from '@chakra-ui/react';
 import { useGetProtocolFeeAmount } from 'hooks/viewStateFacet';
-import { formatFee, getTotalFeesInSarco } from 'lib/utils/helpers';
+import { formatFee, formatSarco, getTotalFeesInSarco } from 'lib/utils/helpers';
 import { useSelector } from 'store/index';
-import { formatEther } from 'ethers/lib/utils';
 import { ethers } from 'ethers';
 import { useSarcoBalance } from 'hooks/sarcoToken/useSarcoBalance';
 import { SummaryErrorIcon } from './SummaryErrorIcon';
@@ -73,7 +72,7 @@ export function SarcophagusSummaryFees() {
               variant="secondary"
               fontSize="xs"
             >
-              {formatEther(protocolFee)} SARCO
+              {formatSarco(protocolFee.toString())} SARCO
             </Text>
           </Flex>
           <Divider

--- a/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
+++ b/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
@@ -9,11 +9,12 @@ import { useSarcoBalance } from 'hooks/sarcoToken/useSarcoBalance';
 import { SummaryErrorIcon } from './SummaryErrorIcon';
 
 export function SarcophagusSummaryFees() {
-  const { uploadPrice, selectedArchaeologists } = useSelector(x => x.embalmState);
+  const { uploadPrice, selectedArchaeologists, resurrection } = useSelector(x => x.embalmState);
   const protocolFeeBasePercentage = useGetProtocolFeeAmount();
   const { balance } = useSarcoBalance();
 
   const { formattedTotalDiggingFees, totalDiggingFees, protocolFee } = getTotalFeesInSarco(
+    resurrection,
     selectedArchaeologists,
     protocolFeeBasePercentage
   );

--- a/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
+++ b/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
@@ -19,6 +19,7 @@ export function useArchaeologistList() {
     failsFilter,
     archAddressSearch,
     showOnlySelectedArchaeologists,
+    showHiddenArchaeologists,
   } = useSelector(s => s.archaeologistListState);
 
   // const onlineArchaeologists = archaeologists.filter(a => a.isOnline);
@@ -111,8 +112,8 @@ export function useArchaeologistList() {
   };
 
   const getArchaeologistListToShow = (args: {
-    showOnlySelectedArchaeologists?: boolean;
-    includeHidden?: boolean;
+    showOnlySelectedArchaeologists: boolean;
+    includeHidden: boolean;
   }): Archaeologist[] => {
     function shouldFilterBySelected(arch: Archaeologist): boolean {
       if (args.showOnlySelectedArchaeologists) {
@@ -129,6 +130,7 @@ export function useArchaeologistList() {
         (arch.ensName?.toLowerCase().includes(archAddressSearch.toLowerCase()) ||
           arch.profile.archAddress.toLowerCase().includes(archAddressSearch.toLowerCase())) &&
         arch.profile.minimumDiggingFeePerSecond
+          // TODO: Import and use constant here
           .mul(2628288)
           .lte(
             (diggingFeesFilter && ethers.utils.parseEther(diggingFeesFilter)) || constants.MaxInt256
@@ -153,6 +155,7 @@ export function useArchaeologistList() {
     onClickSortUnwraps,
     selectedArchaeologists,
     showOnlySelectedArchaeologists,
+    showHiddenArchaeologists,
     SortDirection,
     getArchaeologistListToShow,
     unwrapsFilter,

--- a/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
+++ b/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
@@ -18,7 +18,7 @@ export function useArchaeologistList() {
     unwrapsFilter,
     failsFilter,
     archAddressSearch,
-    showSelectedArchaeologists,
+    showOnlySelectedArchaeologists,
   } = useSelector(s => s.archaeologistListState);
 
   // const onlineArchaeologists = archaeologists.filter(a => a.isOnline);
@@ -26,7 +26,7 @@ export function useArchaeologistList() {
 
   const resurrectionTimeMs = useSelector(s => s.embalmState.resurrection);
 
-  // The arch is filtered out if:
+  // The archaeologist is not hidden out if:
   //  - resurrection time has been set further than the arch's max resurrection time
   //  - Interval between current time and set resurrection time is more than the arch's max rewrap interval
   //  - The arch doesn't have enough free bond to match digging fee based on the set resurrection time
@@ -111,11 +111,11 @@ export function useArchaeologistList() {
   };
 
   const getArchaeologistListToShow = (args: {
-    onlyShowSelected?: boolean;
+    showOnlySelectedArchaeologists?: boolean;
     includeHidden?: boolean;
   }): Archaeologist[] => {
     function shouldFilterBySelected(arch: Archaeologist): boolean {
-      if (args.onlyShowSelected) {
+      if (args.showOnlySelectedArchaeologists) {
         return (
           selectedArchaeologists.findIndex(a => a.profile.peerId === arch.profile.peerId) !== -1
         );
@@ -152,9 +152,8 @@ export function useArchaeologistList() {
     onClickSortFails,
     onClickSortUnwraps,
     selectedArchaeologists,
-    showSelectedArchaeologists,
+    showOnlySelectedArchaeologists,
     SortDirection,
-    // sortedArchaeologists,
     getArchaeologistListToShow,
     unwrapsFilter,
   };

--- a/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
+++ b/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
@@ -125,12 +125,9 @@ export function useArchaeologistList() {
     }
   };
 
-  const getArchaeologistListToShow = (args: {
-    showOnlySelectedArchaeologists: boolean;
-    includeHidden: boolean;
-  }): Archaeologist[] => {
+  const archaeologistListVisible = (): Archaeologist[] => {
     function shouldFilterBySelected(arch: Archaeologist): boolean {
-      if (args.showOnlySelectedArchaeologists) {
+      if (showOnlySelectedArchaeologists) {
         return (
           selectedArchaeologists.findIndex(a => a.profile.peerId === arch.profile.peerId) !== -1
         );
@@ -153,7 +150,9 @@ export function useArchaeologistList() {
         arch.profile.failures.lte(failsFilter || constants.MaxInt256)
     );
 
-    return args.includeHidden ? [...filteredSorted, ...hiddenArchaeologists] : filteredSorted;
+    return showHiddenArchaeologists && !showOnlySelectedArchaeologists
+      ? [...filteredSorted, ...hiddenArchaeologists]
+      : filteredSorted;
   };
 
   return {
@@ -171,7 +170,7 @@ export function useArchaeologistList() {
     showOnlySelectedArchaeologists,
     showHiddenArchaeologists,
     SortDirection,
-    getArchaeologistListToShow,
+    archaeologistListVisible,
     unwrapsFilter,
   };
 }

--- a/src/features/embalm/stepContent/hooks/useSarcophagusParameters.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcophagusParameters.ts
@@ -5,6 +5,7 @@ import { useNetworkConfig } from 'lib/config';
 import { hardhatChainId } from 'lib/config/hardhat';
 import {
   formatAddress,
+  getLowestResurrectionTime,
   getLowestRewrapInterval,
   humanizeUnixTimestamp,
 } from '../../../../lib/utils/helpers';
@@ -41,6 +42,7 @@ export const useSarcophagusParameters = () => {
 
   const isHardhatNetwork = chainId === hardhatChainId;
   const maxRewrapIntervalMs = getLowestRewrapInterval(selectedArchaeologists) * 1000;
+  const maxResurrectionTimeMs = getLowestResurrectionTime(selectedArchaeologists) * 1000; // TODO: will be combined with `getLowestRewrapInterval` above
 
   const resurrectionTimeError = !resurrection
     ? 'Please set a resurrection time'
@@ -64,6 +66,14 @@ export const useSarcophagusParameters = () => {
       value: resurrection ? humanizeUnixTimestamp(resurrection) : null,
       step: Step.NameSarcophagus,
       error: resurrectionTimeError,
+    },
+    {
+      name: 'MAXIMUM RESURRECTION TIME',
+      value: selectedArchaeologists.length
+        ? `${humanizeUnixTimestamp(maxResurrectionTimeMs)}`
+        : null,
+      step: Step.SelectArchaeologists,
+      error: !selectedArchaeologists.length ? 'You have not selected any archaeologists' : null,
     },
     {
       name: 'MAXIMUM REWRAP INTERVAL',

--- a/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
+++ b/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
@@ -71,7 +71,7 @@ export function CreateSarcophagus() {
   const { isSarcophagusFormDataComplete } = useSarcophagusParameters();
   const { balance } = useSarcoBalance();
 
-  const { selectedArchaeologists } = useSelector(x => x.embalmState);
+  const { selectedArchaeologists, resurrection } = useSelector(x => x.embalmState);
   const protocolFeeBasePercentage = useGetProtocolFeeAmount();
 
   const isCreateProcessStarted = (): boolean => {
@@ -138,10 +138,8 @@ export function CreateSarcophagus() {
     }, 10);
   }
 
-  // TODO: Replace the getTotalFeesInSarco with the calculateProjectedDiggingFees() function
-  // The getTotalFeesInSarco function is not up to date with the digging fees per second update. Use
-  // the calculateProjectedDiggingFees() helper function instead
   const { totalDiggingFees, protocolFee } = getTotalFeesInSarco(
+    resurrection,
     selectedArchaeologists,
     protocolFeeBasePercentage
   );

--- a/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
+++ b/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
@@ -17,9 +17,10 @@ import {
 import { useArchaeologistList } from '../hooks/useArchaeologistList';
 import { ChevronLeftIcon, ChevronRightIcon, QuestionIcon } from '@chakra-ui/icons';
 import { SetResurrection } from '../components/SetResurrection';
-import { useSelector } from 'store/index';
+import { useDispatch, useSelector } from 'store/index';
 import moment from 'moment';
 import { useLoadArchaeologists } from '../hooks/useLoadArchaeologists';
+import { toggleShowHiddenArchaeologists } from 'store/archaeologistList/actions';
 
 interface SelectArchaeologistsProps {
   hideHeader?: boolean;
@@ -38,15 +39,24 @@ export function SelectArchaeologists({
   // Load the archaeologists' data
   useLoadArchaeologists();
 
-  const { getArchaeologistListToShow, showOnlySelectedArchaeologists, hiddenArchaeologists } =
-    useArchaeologistList();
+  const dispatch = useDispatch();
+
+  const {
+    getArchaeologistListToShow,
+    showOnlySelectedArchaeologists,
+    hiddenArchaeologists,
+    showHiddenArchaeologists,
+  } = useArchaeologistList();
   const { resurrection } = useSelector(x => x.embalmState);
   const [resurrectionTimeEdit, setResurrectionTimeEdit] = useState<boolean>(false);
   const [paginationSize, setPaginationSize] = useState<number>(defaultPageSize);
 
   const { currentPage, setCurrentPage, pagesCount, pages, pageSize, setPageSize, offset } =
     usePagination({
-      total: getArchaeologistListToShow({ showOnlySelectedArchaeologists }).length,
+      total: getArchaeologistListToShow({
+        showOnlySelectedArchaeologists,
+        includeHidden: showHiddenArchaeologists,
+      }).length,
       initialState: { currentPage: 1, pageSize: defaultPageSize },
       limits: {
         outer: outerLimit,
@@ -56,6 +66,7 @@ export function SelectArchaeologists({
 
   const paginatedArchaeologist = getArchaeologistListToShow({
     showOnlySelectedArchaeologists,
+    includeHidden: showHiddenArchaeologists,
   }).slice(offset, offset + pageSize);
   const resurrectionDate = new Date(resurrection);
 
@@ -220,7 +231,7 @@ export function SelectArchaeologists({
                     </Text>
                     <Tooltip
                       placement="top"
-                      label="These archeologists are hidden because they are not available by your resurrection time. Adjust your resurrection time to include them."
+                      label="These are archeologists that do not meet your configured criteria."
                     >
                       <Icon
                         as={QuestionIcon}
@@ -229,6 +240,19 @@ export function SelectArchaeologists({
                         h={3}
                       />
                     </Tooltip>
+                    <Text
+                      cursor="pointer"
+                      onClick={() => {
+                        returnToFirstPage();
+                        dispatch(toggleShowHiddenArchaeologists());
+                      }}
+                      variant="secondary"
+                      text-align={'bottom'}
+                      as="i"
+                      fontSize={'12'}
+                    >
+                      {showHiddenArchaeologists ? '(hide)' : '(show)'}
+                    </Text>
                   </HStack>
                 ) : (
                   <Box w="200px" />

--- a/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
+++ b/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
@@ -258,27 +258,6 @@ export function SelectArchaeologists({
                   <Box w="200px" />
                 )}
               </Flex>
-
-              <HStack
-                mr={2}
-                mt={3}
-              >
-                <SummaryErrorIcon />
-                <Text
-                  ml={2}
-                  variant="secondary"
-                  textAlign={'center'}
-                >
-                  = accused archaeologists
-                </Text>
-                <Text
-                  text-align={'bottom'}
-                  as="i"
-                  fontSize={'12'}
-                >
-                  (show)
-                </Text>
-              </HStack>
             </Box>
           </VStack>
         </PaginationContainer>

--- a/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
+++ b/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
@@ -138,17 +138,16 @@ export function SelectArchaeologists({
             <Box w={'100%'}>
               <Flex justifyContent={'space-between'}>
                 <Flex px={3}>
-                  <HStack direction="row">
-                    <HStack>
-                      <Text variant="secondary">Items per page:</Text>
-                      <SetPaginationSize
-                        handlePageSizeChange={handlePageSizeChange}
-                        paginationSize={paginationSize}
-                      ></SetPaginationSize>
-                    </HStack>
+                  <HStack>
+                    <Text variant="secondary">Items per page:</Text>
+                    <SetPaginationSize
+                      handlePageSizeChange={handlePageSizeChange}
+                      paginationSize={paginationSize}
+                    ></SetPaginationSize>
                   </HStack>
                 </Flex>
 
+                {/* PAGINATION CONTROLS */}
                 <Flex>
                   <PaginationPrevious
                     backgroundColor={'transparent'}
@@ -164,6 +163,7 @@ export function SelectArchaeologists({
                     ></Icon>
                     Prev
                   </PaginationPrevious>
+                  <Box width="5" />
                   <PaginationPageGroup
                     isInline
                     align="center"
@@ -197,6 +197,7 @@ export function SelectArchaeologists({
                       />
                     ))}
                   </PaginationPageGroup>
+                  <Box width="5" />
                   <PaginationNext
                     backgroundColor={'transparent'}
                     color="brand.950"
@@ -213,44 +214,46 @@ export function SelectArchaeologists({
                   </PaginationNext>
                 </Flex>
 
-                {hiddenArchaeologists.length > 0 ? (
-                  <HStack mr={2}>
-                    <Text variant="secondary">
-                      {hiddenArchaeologists.length} Hidden Archaeologists
-                    </Text>
-                    <Tooltip
-                      placement="top"
-                      label="These are archeologists that do not meet your configured criteria."
-                    >
-                      <Icon
-                        as={QuestionIcon}
-                        color="brand.500"
-                        w={3}
-                        h={3}
-                      />
-                    </Tooltip>
-                    <Text
-                      cursor="pointer"
-                      _hover={{
-                        textDecoration: 'underline',
-                      }}
-                      variant="secondary"
-                      text-align={'bottom'}
-                      as="i"
-                      fontSize={'12'}
-                      onClick={() => {
-                        returnToFirstPage();
-                        dispatch(toggleShowHiddenArchaeologists());
-                      }}
-                    >
-                      {showHiddenArchaeologists ? '(hide)' : '(show)'}
-                    </Text>
-                  </HStack>
-                ) : (
-                  <Box w="200px" />
-                )}
+                <Box width="200px" />
               </Flex>
             </Box>
+
+            {hiddenArchaeologists.length > 0 ? (
+              <HStack mr={2}>
+                <Text variant="secondary">
+                  {hiddenArchaeologists.length} Ineligible Archaeologists
+                </Text>
+                <Tooltip
+                  placement="top"
+                  label="These are archeologists that do not meet your configured criteria."
+                >
+                  <Icon
+                    as={QuestionIcon}
+                    color="brand.500"
+                    w={3}
+                    h={3}
+                  />
+                </Tooltip>
+                <Text
+                  cursor="pointer"
+                  _hover={{
+                    textDecoration: 'underline',
+                  }}
+                  variant="secondary"
+                  text-align={'bottom'}
+                  as="i"
+                  fontSize={'12'}
+                  onClick={() => {
+                    returnToFirstPage();
+                    dispatch(toggleShowHiddenArchaeologists());
+                  }}
+                >
+                  {showHiddenArchaeologists ? '(hide)' : '(show)'}
+                </Text>
+              </HStack>
+            ) : (
+              <></>
+            )}
           </VStack>
         </PaginationContainer>
       </Pagination>

--- a/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
+++ b/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
@@ -242,14 +242,17 @@ export function SelectArchaeologists({
                     </Tooltip>
                     <Text
                       cursor="pointer"
-                      onClick={() => {
-                        returnToFirstPage();
-                        dispatch(toggleShowHiddenArchaeologists());
+                      _hover={{
+                        textDecoration: 'underline',
                       }}
                       variant="secondary"
                       text-align={'bottom'}
                       as="i"
                       fontSize={'12'}
+                      onClick={() => {
+                        returnToFirstPage();
+                        dispatch(toggleShowHiddenArchaeologists());
+                      }}
                     >
                       {showHiddenArchaeologists ? '(hide)' : '(show)'}
                     </Text>

--- a/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
+++ b/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
@@ -40,22 +40,15 @@ export function SelectArchaeologists({
 
   const dispatch = useDispatch();
 
-  const {
-    getArchaeologistListToShow,
-    showOnlySelectedArchaeologists,
-    hiddenArchaeologists,
-    showHiddenArchaeologists,
-  } = useArchaeologistList();
+  const { archaeologistListVisible, hiddenArchaeologists, showHiddenArchaeologists } =
+    useArchaeologistList();
   const { resurrection } = useSelector(x => x.embalmState);
   const [resurrectionTimeEdit, setResurrectionTimeEdit] = useState<boolean>(false);
   const [paginationSize, setPaginationSize] = useState<number>(defaultPageSize);
 
   const { currentPage, setCurrentPage, pagesCount, pages, pageSize, setPageSize, offset } =
     usePagination({
-      total: getArchaeologistListToShow({
-        showOnlySelectedArchaeologists,
-        includeHidden: showHiddenArchaeologists,
-      }).length,
+      total: archaeologistListVisible().length,
       initialState: { currentPage: 1, pageSize: defaultPageSize },
       limits: {
         outer: outerLimit,
@@ -63,10 +56,7 @@ export function SelectArchaeologists({
       },
     });
 
-  const paginatedArchaeologist = getArchaeologistListToShow({
-    showOnlySelectedArchaeologists,
-    includeHidden: showHiddenArchaeologists,
-  }).slice(offset, offset + pageSize);
+  const paginatedArchaeologist = archaeologistListVisible().slice(offset, offset + pageSize);
   const resurrectionDate = new Date(resurrection);
 
   const handlePageChange = (nextPage: number): void => {

--- a/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
+++ b/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
@@ -38,7 +38,7 @@ export function SelectArchaeologists({
   // Load the archaeologists' data
   useLoadArchaeologists();
 
-  const { sortedFilteredArchaeologist, showSelectedArchaeologists, hiddenArchaeologists } =
+  const { getArchaeologistListToShow, showOnlySelectedArchaeologists, hiddenArchaeologists } =
     useArchaeologistList();
   const { resurrection } = useSelector(x => x.embalmState);
   const [resurrectionTimeEdit, setResurrectionTimeEdit] = useState<boolean>(false);
@@ -46,7 +46,7 @@ export function SelectArchaeologists({
 
   const { currentPage, setCurrentPage, pagesCount, pages, pageSize, setPageSize, offset } =
     usePagination({
-      total: sortedFilteredArchaeologist(showSelectedArchaeologists).length,
+      total: getArchaeologistListToShow({ showOnlySelectedArchaeologists }).length,
       initialState: { currentPage: 1, pageSize: defaultPageSize },
       limits: {
         outer: outerLimit,
@@ -54,10 +54,9 @@ export function SelectArchaeologists({
       },
     });
 
-  const paginatedArchaeologist = sortedFilteredArchaeologist(showSelectedArchaeologists).slice(
-    offset,
-    offset + pageSize
-  );
+  const paginatedArchaeologist = getArchaeologistListToShow({
+    showOnlySelectedArchaeologists,
+  }).slice(offset, offset + pageSize);
   const resurrectionDate = new Date(resurrection);
 
   const handlePageChange = (nextPage: number): void => {

--- a/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
+++ b/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
@@ -1,6 +1,5 @@
 import { Flex, Heading, Text, VStack, HStack, Icon, Box, Tooltip, chakra } from '@chakra-ui/react';
 import { useState } from 'react';
-import { SummaryErrorIcon } from '../components/SummaryErrorIcon';
 import { ArchaeologistList } from '../components/ArchaeologistList';
 import { SetPaginationSize, IPageSizeSetByOption } from '../components/SetPaginationSize';
 import { ArchaeologistHeader } from '../components/ArchaeologistHeader';

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -4,6 +4,7 @@ export const chunkedUploaderFileSize = 50_000_000;
 export const bundlrBalanceDecimals = 8;
 export const uploadPriceDecimals = 8;
 export const minimumResurrection = 30_000;
+export const monthSeconds = 2628288;
 export const maxTotalArchaeologists = 255; // limited by the shamir secret sharing algorithm
 export const discordBuildersLink =
   'https://discord.com/channels/839548879216181309/938467660595879986';

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -148,15 +148,38 @@ export function formatFee(value: number | string, fixed = 2): string {
 }
 
 /**
- * Given a list of archaeologists, sums up their digging fees
+ * @param diggingFeeRates An array of the archaeologist's digging fees per second rates
+ * @param resurrectionTimestamp The timestamp of the resurrection in ms
+ * @returns The total projected digging fees as a string
+ */
+export function calculateProjectedDiggingFees(
+  diggingFeeRates: BigNumber[],
+  resurrectionTimestamp: number
+): BigNumber {
+  if (resurrectionTimestamp === 0) return ethers.constants.Zero;
+  const totalDiggingFeesPerSecond = diggingFeeRates.reduce(
+    (acc, curr) => acc.add(curr),
+    ethers.constants.Zero
+  );
+
+  const resurrectionSeconds = Math.floor(resurrectionTimestamp / 1000);
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  return totalDiggingFeesPerSecond.mul(resurrectionSeconds - nowSeconds);
+}
+
+/**
+ * Returns the estimated total digging fees, and protocol fee,
+ * that the embalmer will be due to pay.
  */
 export function getTotalFeesInSarco(
+  resurrectionTimestamp: number,
   archaeologists: Archaeologist[],
   protocolFeeBasePercentage?: number
 ) {
-  const totalDiggingFees = archaeologists.reduce(
-    (acc, curr) => acc.add(curr.profile.minimumDiggingFeePerSecond),
-    ethers.constants.Zero
+  const totalDiggingFees = calculateProjectedDiggingFees(
+    archaeologists.map(a => a.profile.minimumDiggingFeePerSecond),
+    resurrectionTimestamp
   );
 
   // protocolFeeBasePercentage is pulled from the chain, temp show 0 until it loads
@@ -169,28 +192,6 @@ export function getTotalFeesInSarco(
     formattedTotalDiggingFees: formatEther(totalDiggingFees),
     protocolFee,
   };
-}
-
-/**
- *
- * @param diggingFeeRates An array of the archaeologist's digging fees per second rates
- * @param resurrectionTimestamp The timestamp of the resurrection in ms
- * @returns The total projected digging fees as a string
- */
-export function calculateProjectedDiggingFees(
-  diggingFeeRates: BigNumber[],
-  resurrectionTimestamp: number
-): string {
-  if (resurrectionTimestamp === 0) return '0';
-  const totalDiggingFeesPerSecond = diggingFeeRates.reduce(
-    (acc, curr) => acc.add(curr),
-    ethers.constants.Zero
-  );
-
-  const resurrectionSeconds = Math.floor(resurrectionTimestamp / 1000);
-  const nowSeconds = Math.floor(Date.now() / 1000);
-
-  return totalDiggingFeesPerSecond.mul(resurrectionSeconds - nowSeconds).toString();
 }
 
 /**

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -103,7 +103,7 @@ export const filterSplit = <T>(arr: T[], predicate: (item: T) => boolean): [T[],
 };
 
 export function humanizeUnixTimestamp(unixTimestamp: number): string {
-  return new Date(unixTimestamp).toLocaleDateString('en-US');
+  return new Date(unixTimestamp).toLocaleDateString();
 }
 
 export function removeNonIntChars(value: string): string {

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -169,6 +169,30 @@ export function calculateProjectedDiggingFees(
 }
 
 /**
+ * Reduces the number of decimals displayed for sarco value (or any float). If the value is a whole
+ * number, decimals will be hidden. If a precision of 2 is set and the value is 0.0000452, then
+ * "< 0.01" will be returned.
+ *
+ * @param valueInWei The value to be formateed
+ * @param precision The number of decimal places to show
+ * @returns A formatted value
+ */
+export function formatSarco(valueInWei: string | number, precision: number = 2): string {
+  const value = formatEther(valueInWei.toString());
+  const numericValue: number = Number(value);
+  if (isNaN(numericValue)) {
+    return value.toString();
+  }
+  const formattedValue: string = numericValue.toFixed(precision).replace(/\.?0*$/, '');
+
+  if (formattedValue === '0' && parseFloat(value) > 0) {
+    return `< 0.${'0'.repeat(precision - 1)}1`;
+  }
+
+  return formattedValue;
+}
+
+/**
  * Returns the estimated total digging fees, and protocol fee,
  * that the embalmer will be due to pay.
  */
@@ -189,7 +213,7 @@ export function getTotalFeesInSarco(
 
   return {
     totalDiggingFees,
-    formattedTotalDiggingFees: formatEther(totalDiggingFees),
+    formattedTotalDiggingFees: formatSarco(totalDiggingFees.toString()),
     protocolFee,
   };
 }
@@ -240,30 +264,6 @@ export async function sign(
   const dataHashBytes = ethers.utils.arrayify(dataHash);
   const signature = await signer.signMessage(dataHashBytes);
   return ethers.utils.splitSignature(signature);
-}
-
-/**
- * Reduces the number of decimals displayed for sarco value (or any float). If the value is a whole
- * number, decimals will be hidden. If a precision of 2 is set and the value is 0.0000452, then
- * "< 0.01" will be returned.
- *
- * @param valueInWei The value to be formateed
- * @param precision The number of decimal places to show
- * @returns A formatted value
- */
-export function formatSarco(valueInWei: string | number, precision: number = 2): string {
-  const value = formatEther(valueInWei.toString());
-  const numericValue: number = Number(value);
-  if (isNaN(numericValue)) {
-    return value.toString();
-  }
-  const formattedValue: string = numericValue.toFixed(precision).replace(/\.?0*$/, '');
-
-  if (formattedValue === '0' && parseFloat(value) > 0) {
-    return `< 0.${'0'.repeat(precision - 1)}1`;
-  }
-
-  return formattedValue;
 }
 
 // This function estimates sarco per month based on average number of days per month. This value is

--- a/src/store/archaeologistList/actions.ts
+++ b/src/store/archaeologistList/actions.ts
@@ -5,6 +5,7 @@ import { ActionMap } from '../ActionMap';
 export enum ActionType {
   SetSortDirection = 'EMBALM_SET_ARCHAEOLOGISTS_SORT_DIRECTION',
   SetShowSelectedArchaeologists = 'EMBALM_SET_SHOW_SELECTED_ARCHAEOLOGISTS',
+  ToggleShowHiddenArchaeologists = 'EMBALM_TOGGLE_SHOW_HIDDEN_ARCHAEOLOGISTS',
   SetDiggingFeesFilter = 'EMBALM_SET_DIGGING_FEES_FILTER',
   SetUnwrapsFilter = 'EMBALM_SET_UNWRAPS_FILTER',
   SetFailsFilter = 'EMBALM_SET_FAILS_FILTER',
@@ -32,6 +33,7 @@ type ArchaeologistListPayload = {
   [ActionType.SetFailsFilter]: { filter: string };
   [ActionType.SetArchAddressSearch]: { search: string };
   [ActionType.SetShowSelectedArchaeologists]: { selected: boolean };
+  [ActionType.ToggleShowHiddenArchaeologists]: {};
 };
 
 export function setSortDirection(
@@ -89,6 +91,13 @@ export function setShowSelectedArchaeologists(selected: boolean): ArchaeologistL
     payload: {
       selected,
     },
+  };
+}
+
+export function toggleShowHiddenArchaeologists(): ArchaeologistListActions {
+  return {
+    type: ActionType.ToggleShowHiddenArchaeologists,
+    payload: {},
   };
 }
 

--- a/src/store/archaeologistList/reducer.ts
+++ b/src/store/archaeologistList/reducer.ts
@@ -7,7 +7,7 @@ export interface ArchaeologistListState {
   unwrapsFilter: string;
   failsFilter: string;
   archAddressSearch: string;
-  showSelectedArchaeologists: boolean;
+  showOnlySelectedArchaeologists: boolean;
 }
 
 export const archaeologistListInitialState: ArchaeologistListState = {
@@ -16,7 +16,7 @@ export const archaeologistListInitialState: ArchaeologistListState = {
   unwrapsFilter: '',
   failsFilter: '',
   archAddressSearch: '',
-  showSelectedArchaeologists: false,
+  showOnlySelectedArchaeologists: false,
 };
 
 export function archaeologistListReducer(
@@ -46,7 +46,7 @@ export function archaeologistListReducer(
       return { ...state, archAddressSearch: action.payload.search };
 
     case ActionType.SetShowSelectedArchaeologists:
-      return { ...state, showSelectedArchaeologists: action.payload.selected };
+      return { ...state, showOnlySelectedArchaeologists: action.payload.selected };
 
     default:
       return state;

--- a/src/store/archaeologistList/reducer.ts
+++ b/src/store/archaeologistList/reducer.ts
@@ -8,6 +8,7 @@ export interface ArchaeologistListState {
   failsFilter: string;
   archAddressSearch: string;
   showOnlySelectedArchaeologists: boolean;
+  showHiddenArchaeologists: boolean;
 }
 
 export const archaeologistListInitialState: ArchaeologistListState = {
@@ -17,6 +18,7 @@ export const archaeologistListInitialState: ArchaeologistListState = {
   failsFilter: '',
   archAddressSearch: '',
   showOnlySelectedArchaeologists: false,
+  showHiddenArchaeologists: false,
 };
 
 export function archaeologistListReducer(
@@ -47,6 +49,9 @@ export function archaeologistListReducer(
 
     case ActionType.SetShowSelectedArchaeologists:
       return { ...state, showOnlySelectedArchaeologists: action.payload.selected };
+
+    case ActionType.ToggleShowHiddenArchaeologists:
+      return { ...state, showHiddenArchaeologists: !state.showHiddenArchaeologists };
 
     default:
       return state;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export interface Archaeologist {
   isOnline: boolean;
   fullPeerId?: PeerId;
   signature?: string;
+  hiddenReason?: string;
   exception?: ArchaeologistException;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export interface Archaeologist {
   isOnline: boolean;
   fullPeerId?: PeerId;
   signature?: string;
+  ensName?: string;
   hiddenReason?: string;
   exception?: ArchaeologistException;
 }


### PR DESCRIPTION
Updates UX around hidden archaeologists feature; includes their maximum resurrection time. 

### Screenshots:

#### Button to show hidden archs:

<img width="1194" alt="Screenshot 2023-02-22 at 14 11 59" src="https://user-images.githubusercontent.com/7101382/220646191-ceb33547-e6a5-46d6-8a6d-349a482d321c.png">

#### Shown hidden arch row UI + tooltip:

<img width="1104" alt="Screenshot 2023-02-22 at 14 12 19" src="https://user-images.githubusercontent.com/7101382/220646279-4fe04141-dd37-45f8-aade-a79dc0a97db3.png">

#### Max resurrection interval tooltip:

<img width="1125" alt="Screenshot 2023-02-22 at 14 13 11" src="https://user-images.githubusercontent.com/7101382/220646545-ae2f9750-5d76-4b00-8c08-9d3607490ea9.png">


#### Removed ability to select hidden archaeologists:

<img width="939" alt="Screenshot 2023-02-22 at 14 14 02" src="https://user-images.githubusercontent.com/7101382/220646812-3b1b5f1d-11e4-485b-94db-fad1c7b551b6.png">

#### However it is still possible to select an arch with a valid resurrection date set, then update that date to one that will clash with the arch. UI Looks like this in that case:

<img width="1152" alt="Screenshot 2023-02-22 at 14 15 07" src="https://user-images.githubusercontent.com/7101382/220647163-5d097955-4541-4a6f-8269-3e170a6f12bc.png">

#### Clicking "show selected" does not show the hidden but selected archaeologist (this is a bug):

<img width="928" alt="Screenshot 2023-02-22 at 14 17 42" src="https://user-images.githubusercontent.com/7101382/220647906-22e94870-6f58-42dd-9fda-c99ae63adbdc.png">

--- 

A possible follow up task is to add UI somewhere to alert the user if they have accidentally selected a hidden archaeologist, because creation will fail if they proceed with that selection.

This UX may change depending on feedback, so leaving as is for now.
