### PR TITLE
Public Key retry

### DIFF
--- a/src/features/embalm/stepContent/components/RecoverPublicKey.tsx
+++ b/src/features/embalm/stepContent/components/RecoverPublicKey.tsx
@@ -3,6 +3,7 @@ import { useRecoverPublicKey, ErrorStatus } from '../hooks/useRecoverPublicKey';
 import { setRecipientState, RecipientSetByOption } from 'store/embalm/actions';
 import { useDispatch, useSelector } from 'store/index';
 import { SarcoAlert } from 'components/SarcoAlert';
+import { useEnterKeyCallback } from 'hooks/useEnterKeyCallback';
 
 interface IErrorStatusMap {
   alertMessage: string;
@@ -33,6 +34,8 @@ export function RecoverPublicKey() {
   const { recipientState } = useSelector(x => x.embalmState);
 
   const { recoverPublicKey, isLoading, errorStatus, clearErrorStatus } = useRecoverPublicKey();
+
+  useEnterKeyCallback(() => recoverPublicKey(recipientState.address));
 
   async function handleOnClick(): Promise<void> {
     if (recipientState.address !== '') await recoverPublicKey(recipientState.address);

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useDialArchaeologists.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useDialArchaeologists.ts
@@ -8,6 +8,7 @@ import { PeerId } from '@libp2p/interface-peer-id';
 import { Connection } from '@libp2p/interface-connection';
 import { Multiaddr, multiaddr } from '@multiformats/multiaddr';
 import { CancelCreateToken } from './useCreateSarcophagus';
+import { wait } from 'lib/utils/helpers';
 
 export function useDialArchaeologists() {
   const dispatch = useDispatch();
@@ -71,7 +72,6 @@ export function useDialArchaeologists() {
     async (_: any, cancelToken: CancelCreateToken) => {
       const MAX_RETRIES = 5;
       const WAIT_BETWEEN_RETRIES = 300;
-      const wait = (ms: number) => new Promise(res => setTimeout(res, ms));
 
       const dialArchaeologistWithRetry = async (
         dialFn: Function,

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -282,3 +282,5 @@ export function convertSarcoPerSecondToPerMonth(diggingFeePerSecond: string): st
   const averageNumberOfSecondsPerMonth = 2628288;
   return BigNumber.from(diggingFeePerSecond).mul(averageNumberOfSecondsPerMonth).toString();
 }
+
+export const wait = (ms: number) => new Promise(res => setTimeout(res, ms));


### PR DESCRIPTION
Adds retry to public retrieval from address. 

Occasionally the api call fails due to rate limiting. This PR retries the call ONE more time, after 3 seconds. Testing showed the 3-second wait always results in success on the 2nd attempt.