### PR TITLE
346 rewrap bound calculation

### DIFF
--- a/src/features/sarcophagi/components/Rewrap.tsx
+++ b/src/features/sarcophagi/components/Rewrap.tsx
@@ -38,25 +38,22 @@ export function Rewrap() {
 
   const nowMs = Date.now();
 
-  const maxRewrapIntervalFromSarcophagusSec = BigNumber.from(
-    sarcophagus?.maximumRewrapInterval?.toNumber() ?? 0
-  );
+  const maxRewrapIntervalFromSarcophagusSec = sarcophagus?.maximumRewrapInterval?.toNumber() ?? 0;
 
-  // The calculated max rewrap interval is the ( new resurrection time - previous resurrection time ) * 2
+  // The calculated max rewrap interval is
+  // ( new resurrection time - previous resurrection time ) * (200 / cursed bond percentage)
   // Defaults to max possible number
-  // TODO: Update this equation to handle a modifiable multiplier
   const maxRewrapIntervalCalculatedSec = sarcophagus
-    ? sarcophagus.resurrectionTime.sub(sarcophagus.previousRewrapTime).mul(2)
-    : ethers.constants.MaxUint256;
-  // }
+    ? (Number(sarcophagus.resurrectionTime) - Number(sarcophagus.previousRewrapTime)) *
+      (200 / sarcophagus.cursedBondPercentage)
+    : Number.MAX_SAFE_INTEGER;
 
   // The max rewrap interval is the lesser value of the max rewrap interval from the sarcophagus and
   // the calculated max rewrap interval
-  const maxRewrapIntervalMs = (
-    maxRewrapIntervalFromSarcophagusSec.lt(maxRewrapIntervalCalculatedSec)
+  const maxRewrapIntervalMs =
+    (maxRewrapIntervalFromSarcophagusSec < maxRewrapIntervalCalculatedSec
       ? maxRewrapIntervalFromSarcophagusSec
-      : maxRewrapIntervalCalculatedSec
-  ).mul(1000);
+      : maxRewrapIntervalCalculatedSec) * 1000;
 
   function handleCustomDateChange(date: Date | null): void {
     // Ensure that selected date is in the future

--- a/src/hooks/viewStateFacet/useGetSarcophagusArchaeologists.ts
+++ b/src/hooks/viewStateFacet/useGetSarcophagusArchaeologists.ts
@@ -18,5 +18,5 @@ export function useGetSarcophagusArchaeologists(
     })),
   });
 
-  return (data as SarcophagusArchaeologist[]) || [];
+  return (data?.filter(d => d) as SarcophagusArchaeologist[]) || [];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,6 +82,7 @@ export interface SarcophagusResponseContract {
   isCleaned: boolean;
   name: string;
   threshold: number;
+  cursedBondPercentage: number;
   maximumRewrapInterval: BigNumber;
   arweaveTxId: string;
   embalmerAddress: string;


### PR DESCRIPTION
Updates the max rewrap time available based on the new calculation involving the cursed bond multiplier. 

The message at the bottom of this container now shows the correct date.

![image](https://user-images.githubusercontent.com/34484576/222296193-e203cfaf-f32c-42b3-8be4-9b630cfaed37.png)
