### PR TITLE
skip 0 hash priv key in resurrection

### DIFF
--- a/src/features/resurrection/hooks/useResurrection.ts
+++ b/src/features/resurrection/hooks/useResurrection.ts
@@ -72,6 +72,11 @@ export function useResurrection(sarcoId: string, recipientPrivateKey: string) {
       // with the recipient's key, and an outer layer of encryption with the archaeologist's key.
       const decryptedKeyShares: Buffer[] = [];
       for await (const arch of archaeologists) {
+        // If arch failed to publish private key, continue to next key
+        if (arch.privateKey === ethers.constants.HashZero) {
+          continue;
+        }
+
         const archDoubleEncryptedKeyShare = arweaveFile.keyShares[arch.publicKey];
 
         // Decrypt outer layer with arch private key


### PR DESCRIPTION
Empty private keys from archs failing to be unwrap were attempting to be decrypted resulting in a failure to resurrect.

Skip these archs when resurrecting.