### PR TITLE
Make date change reset arch selections

### DIFF
--- a/src/features/embalm/stepContent/hooks/useSarcophagusParameters.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcophagusParameters.ts
@@ -141,8 +141,11 @@ export const useSarcophagusParameters = () => {
       .every(step => getStatus(step) === StepStatus.Complete);
   };
 
+  const isError = Object.values(sarcophagusParameters).some(p => p.error);
+
   return {
     sarcophagusParameters,
     isSarcophagusFormDataComplete,
+    isError,
   };
 };

--- a/src/features/embalm/stepContent/hooks/useSetResurrection.ts
+++ b/src/features/embalm/stepContent/hooks/useSetResurrection.ts
@@ -3,9 +3,10 @@ import { minimumResurrection } from 'lib/constants';
 import moment from 'moment';
 import { useEffect, useState } from 'react';
 import {
+  setCustomResurrectionDate,
   setResurrection,
   setResurrectionRadioValue,
-  setCustomResurrectionDate,
+  setSelectedArchaeologists,
 } from 'store/embalm/actions';
 import { useDispatch, useSelector } from 'store/index';
 
@@ -28,14 +29,17 @@ export function useSetResurrection() {
 
   function handleRadioChange(nextValue: string) {
     dispatch(setResurrectionRadioValue(nextValue));
+    dispatch(setSelectedArchaeologists([]));
   }
 
   function handleCustomDateChange(date: Date | null) {
     dispatch(setCustomResurrectionDate(date));
+    dispatch(setSelectedArchaeologists([]));
   }
 
   function handleCustomDateClick() {
     dispatch(setResurrectionRadioValue('Other'));
+    dispatch(setSelectedArchaeologists([]));
   }
 
   // value and onChange are passed in to this hook instead of into a RadioGroup component.

--- a/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
+++ b/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
@@ -68,7 +68,7 @@ export function CreateSarcophagus() {
     clearSarcophagusState,
   } = useCreateSarcophagus(createSarcophagusStages, embalmerFacet!, sarcoToken!);
 
-  const { isSarcophagusFormDataComplete } = useSarcophagusParameters();
+  const { isSarcophagusFormDataComplete, isError } = useSarcophagusParameters();
   const { balance } = useSarcoBalance();
 
   const { selectedArchaeologists, resurrection } = useSelector(x => x.embalmState);
@@ -161,7 +161,9 @@ export function CreateSarcophagus() {
               mt={9}
               onClick={handleCreate}
               disabled={
-                balance?.lte(totalDiggingFees.add(protocolFee)) || !isSarcophagusFormDataComplete()
+                balance?.lte(totalDiggingFees.add(protocolFee)) ||
+                !isSarcophagusFormDataComplete() ||
+                isError
               }
             >
               Create Sarcophagus

--- a/src/store/embalm/actions.ts
+++ b/src/store/embalm/actions.ts
@@ -246,6 +246,15 @@ export function deselectArchaeologist(address: string): EmbalmActions {
   };
 }
 
+export function setSelectedArchaeologists(archaeologists: Archaeologist[]): EmbalmActions {
+  return {
+    type: ActionType.SetSelectedArchaeologists,
+    payload: {
+      selectedArchaeologists: archaeologists,
+    },
+  };
+}
+
 export function setArchaeologistFullPeerId(peerId: PeerId): EmbalmActions {
   return {
     type: ActionType.SetArchaeologistFullPeerId,


### PR DESCRIPTION
If you go through the sarco creation process then change the resurrection date on the first step, an arch that was previously selected may not be valid because the free bond required has changed. This PR makes it so that a change to the resurrection date clears the arch selections so that the user will have to select the archs again. 