### PR TITLE
Add archaeologists to sarcophagus details page

### DIFF
--- a/src/features/sarcophagi/components/ArchaeologistDetailsCollapse.tsx
+++ b/src/features/sarcophagi/components/ArchaeologistDetailsCollapse.tsx
@@ -1,0 +1,57 @@
+import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons';
+import { Collapse, Flex, IconButton, Text, useDisclosure, VStack } from '@chakra-ui/react';
+import { SarcophagusArchaeologist } from 'types';
+import { ArchaeologistDetailItem } from './ArchaeologistDetailsItem';
+
+interface ArchaeologistsDetailsCollapseProps {
+  archaeologists: (SarcophagusArchaeologist & { address: `0x${string}` })[];
+}
+
+export function ArchaeologistsDetailsCollapse({
+  archaeologists,
+}: ArchaeologistsDetailsCollapseProps) {
+  const { isOpen, onToggle } = useDisclosure();
+
+  return (
+    <>
+      <Flex align="center">
+        <Text
+          cursor="pointer"
+          _hover={{ textDecoration: 'underline' }}
+          onClick={onToggle}
+        >
+          <Text>Archaeologists ({archaeologists.length})</Text>
+        </Text>
+        <IconButton
+          aria-label="Expand details"
+          bg="none"
+          color="brand.950"
+          size="xs"
+          _hover={{
+            bg: 'none',
+          }}
+          _active={{
+            bg: 'none',
+          }}
+          icon={isOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}
+          onClick={onToggle}
+        />
+      </Flex>
+      <Collapse in={isOpen}>
+        <VStack
+          align="left"
+          pl={4}
+          mt={3}
+          spacing={5}
+        >
+          {archaeologists.map(arch => (
+            <ArchaeologistDetailItem
+              key={arch.address}
+              archaeologist={arch}
+            />
+          ))}
+        </VStack>
+      </Collapse>
+    </>
+  );
+}

--- a/src/features/sarcophagi/components/ArchaeologistDetailsItem.tsx
+++ b/src/features/sarcophagi/components/ArchaeologistDetailsItem.tsx
@@ -1,0 +1,52 @@
+import { Text, VStack } from '@chakra-ui/react';
+import { ethers } from 'ethers';
+import { useNetworkConfig } from 'lib/config';
+import { convertSarcoPerSecondToPerMonth, formatSarco } from 'lib/utils/helpers';
+import { SarcophagusArchaeologist } from 'types';
+import { useEnsName } from 'wagmi';
+interface ArchaeologistDetailItemProps {
+  archaeologist: SarcophagusArchaeologist & { address: `0x${string}` };
+}
+
+export function ArchaeologistDetailItem({ archaeologist }: ArchaeologistDetailItemProps) {
+  const networkConfig = useNetworkConfig();
+  const { data: ensName } = useEnsName({
+    address: archaeologist.address,
+    chainId: networkConfig.chainId,
+  });
+
+  return (
+    <VStack
+      align="left"
+      key={archaeologist.address}
+      spacing={1}
+    >
+      {archaeologist.isAccused && (
+        <Text
+          color="red"
+          textTransform="uppercase"
+        >
+          Accused
+        </Text>
+      )}
+      {archaeologist.privateKey !== ethers.constants.HashZero && (
+        <Text
+          color="green"
+          textTransform="uppercase"
+        >
+          Unwrapped
+        </Text>
+      )}
+      <Text>Address: {ensName ?? archaeologist.address}</Text>
+      <Text>
+        Digging Fee Per Month:{' '}
+        {formatSarco(convertSarcoPerSecondToPerMonth(archaeologist.diggingFeePerSecond.toString()))}{' '}
+        SARCO
+      </Text>
+      <Text>Public Key: {archaeologist.publicKey}</Text>
+      {archaeologist.privateKey !== ethers.constants.HashZero && (
+        <Text>Private Key: {archaeologist.privateKey}</Text>
+      )}
+    </VStack>
+  );
+}

--- a/src/features/sarcophagi/components/Details.tsx
+++ b/src/features/sarcophagi/components/Details.tsx
@@ -31,7 +31,10 @@ export function Details() {
   const canEmbalmerClean = useGetEmbalmerCanClean(sarcophagus);
 
   return (
-    <Flex direction="column">
+    <Flex
+      pb={100}
+      direction="column"
+    >
       {sarcophagus && (
         <DetailsCollapse
           id={id}

--- a/src/features/sarcophagi/components/DetailsCollapse.tsx
+++ b/src/features/sarcophagi/components/DetailsCollapse.tsx
@@ -1,7 +1,9 @@
 import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons';
 import { Collapse, Flex, IconButton, Text, useDisclosure, VStack } from '@chakra-ui/react';
 import { ethers } from 'ethers';
+import { useGetSarcophagusArchaeologists } from 'hooks/viewStateFacet';
 import { Sarcophagus } from 'types';
+import { ArchaeologistsDetailsCollapse } from './ArchaeologistDetailsCollapse';
 
 interface DetailsCollapseProps {
   id?: string;
@@ -13,6 +15,16 @@ export function DetailsCollapse({
   sarcophagus,
 }: DetailsCollapseProps) {
   const { isOpen, onToggle } = useDisclosure();
+
+  const archaeologists = useGetSarcophagusArchaeologists(
+    sarcophagus.id,
+    sarcophagus.archaeologistAddresses
+  );
+
+  const archaeologistsWithAddresses = archaeologists.map((a, i) => ({
+    ...a,
+    address: sarcophagus.archaeologistAddresses[i] as `0x${string}`,
+  }));
 
   return (
     <>
@@ -52,7 +64,7 @@ export function DetailsCollapse({
           <Text>Embalmer Address: {sarcophagus?.embalmerAddress}</Text>
           <Text>Recipient Address: {sarcophagus?.recipientAddress}</Text>
           <Text>Minimum Archaeologists: {sarcophagus?.threshold}</Text>
-          <Text>Total Archaeologists: {sarcophagus?.archaeologistAddresses?.length}</Text>
+          <ArchaeologistsDetailsCollapse archaeologists={archaeologistsWithAddresses} />
         </VStack>
       </Collapse>
     </>

--- a/src/hooks/viewStateFacet/index.ts
+++ b/src/hooks/viewStateFacet/index.ts
@@ -9,4 +9,5 @@ export { useGetFreeBond } from './useGetFreeBond';
 export { useGetProtocolFeeAmount } from './useGetProtocolFeeAmount';
 export { useGetRecipientSarcophagi } from './useGetRecipientSarcophagi';
 export { useGetSarcophagusArchaeologist } from './useGetSarcophagusArchaeologist';
+export { useGetSarcophagusArchaeologists } from './useGetSarcophagusArchaeologists';
 export { useGetSarcophagus } from './useGetSarcophagus';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,7 +37,6 @@ export interface ArchaeologistException {
 export interface SarcophagusArchaeologist {
   diggingFeePerSecond: number;
   isAccused: boolean;
-  diggingFeesPaid: number;
   publicKey: string;
   privateKey: string;
 }


### PR DESCRIPTION
## Add archaeologists to sarcophagus details page 

This PR adds archaeologists to the sarcophagus details page. 
- Shows if an arch has been accused 
- Shows if an arch has unwrapped and shows private key they unwrapped with
- Shows ens addresses if applicable

### A resurrected sarcophagus
![image](https://user-images.githubusercontent.com/34484576/223546254-4e1a84ca-2ec6-4f02-a0f8-f91e0aec51d2.png)

### An active sarcophagus
![image](https://user-images.githubusercontent.com/34484576/223546471-3631e919-90eb-40c7-88aa-943e42b00c6e.png)

### When an arch is accused 
![image](https://user-images.githubusercontent.com/34484576/223546568-300e2c89-b3d0-494a-a75b-d02e1d044f51.png)

