### PR TITLE
Add a basic admin dashboard page

### DIFF
--- a/src/features/sarcophagi/components/AdminSarcophagi.tsx
+++ b/src/features/sarcophagi/components/AdminSarcophagi.tsx
@@ -1,0 +1,47 @@
+import { Flex, Spinner, Text } from '@chakra-ui/react';
+import { EmbalmerFacet__factory } from '@sarcophagus-org/sarcophagus-v2-contracts';
+import { useNetworkConfig } from 'lib/config';
+import { useCallback, useEffect, useState } from 'react';
+import { useProvider } from 'wagmi';
+
+export function AdminSarcophagi() {
+  const networkConfig = useNetworkConfig();
+  const provider = useProvider();
+  const [sarcophagusCount, setSarcophagusCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchEvents = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const contract = EmbalmerFacet__factory.connect(networkConfig.diamondDeployAddress, provider);
+      const events = await contract.queryFilter('CreateSarcophagus');
+      setSarcophagusCount(events.length);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [networkConfig.diamondDeployAddress, provider]);
+
+  useEffect(() => {
+    fetchEvents();
+  }, [fetchEvents]);
+
+  if (isLoading) {
+    return (
+      <Flex>
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction="column">
+      <Text>This page is a work in progress.</Text>
+      <Text mt={3}>
+        There are currently {sarcophagusCount}{' '}
+        {sarcophagusCount === 1 ? 'sarcophagus' : 'sarocphagi'}.
+      </Text>
+    </Flex>
+  );
+}

--- a/src/pages/AdminDashboardPage.tsx
+++ b/src/pages/AdminDashboardPage.tsx
@@ -1,0 +1,16 @@
+import { Flex } from '@chakra-ui/react';
+import { AdminSarcophagi } from 'features/sarcophagi/components/AdminSarcophagi';
+
+export function AdminDashBoardPage() {
+  return (
+    <Flex justify="center">
+      <Flex
+        w={775}
+        mt={12}
+        mb="84px"
+      >
+        <AdminSarcophagi />
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,6 +18,7 @@ import { CreateSarcophagusContextProvider } from 'features/embalm/stepContent/co
 import { WalletDisconnectPage } from './WalletDisconnectPage';
 import { useBundlrSession } from 'features/embalm/stepContent/hooks/useBundlrSession';
 import { AccusePage } from './AccusePage';
+import { AdminDashBoardPage } from './AdminDashboardPage';
 
 export enum RouteKey {
   ARCHEOLOGIST_PAGE,
@@ -30,6 +31,7 @@ export enum RouteKey {
   SARCOPHAGUS_CREATED,
   THEME_TEST_PAGE,
   ACCUSE_PAGE,
+  ADMIN_DASHBOARD_PAGE,
 }
 
 export const RoutesPathMap: { [key: number]: string } = {
@@ -43,6 +45,7 @@ export const RoutesPathMap: { [key: number]: string } = {
   [RouteKey.SARCOPHAGUS_CREATED]: '/sarcophagus-created',
   [RouteKey.THEME_TEST_PAGE]: '/theme-test',
   [RouteKey.ACCUSE_PAGE]: '/accuse',
+  [RouteKey.ADMIN_DASHBOARD_PAGE]: '/admin-dashboard',
 };
 
 export function Pages() {
@@ -119,6 +122,12 @@ export function Pages() {
     {
       path: RoutesPathMap[RouteKey.THEME_TEST_PAGE],
       element: <ThemeTestPage />,
+      label: '',
+      hidden: true,
+    },
+    {
+      path: RoutesPathMap[RouteKey.ADMIN_DASHBOARD_PAGE],
+      element: <AdminDashBoardPage />,
       label: '',
       hidden: true,
     },


### PR DESCRIPTION
## Admin dashboard page 
Adds a basic dashboard page for admins. Currently it only shows the number of sarcophagi that have been created.

![image](https://user-images.githubusercontent.com/34484576/223555097-f974089b-3258-4c44-9bf5-d56e133a9d8c.png)
