### PR TITLE
Refactor SelectArchaeologists -- show all online on dashboard

### DIFF
--- a/src/features/embalm/stepContent/components/ArchaeologistList.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistList.tsx
@@ -29,7 +29,9 @@ import { ArchaeologistListItem } from './ArchaeologistListItem';
 export function ArchaeologistList({
   showDial,
   paginatedArchaeologist,
+  totalCount,
 }: {
+  totalCount: number;
   showDial?: boolean;
   paginatedArchaeologist: Archaeologist[];
 }) {
@@ -37,7 +39,6 @@ export function ArchaeologistList({
     handleCheckArchaeologist,
     selectedArchaeologists,
     hiddenArchaeologists,
-    archaeologistListVisible,
     onClickSortDiggingFees,
     onClickSortUnwraps,
     onClickSortFails,
@@ -104,7 +105,7 @@ export function ArchaeologistList({
                         color="text.primary"
                         p={'0.5'}
                       >
-                        Archaeologists ({archaeologistListVisible()?.length})
+                        Archaeologists ({totalCount})
                       </Button>
                       <FilterInput
                         filterName={SortFilterType.ADDRESS_SEARCH}

--- a/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
+++ b/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
@@ -128,7 +128,7 @@ export function useArchaeologistList() {
     }
   };
 
-  const archaeologistListVisible = (): Archaeologist[] => {
+  const archaeologistListVisible = (arg: { forceShowHidden: boolean }): Archaeologist[] => {
     function shouldFilterBySelected(arch: Archaeologist): boolean {
       if (showOnlySelectedArchaeologists) {
         return (
@@ -152,7 +152,7 @@ export function useArchaeologistList() {
         arch.profile.failures.lte(failsFilter || constants.MaxInt256)
     );
 
-    return showHiddenArchaeologists && !showOnlySelectedArchaeologists
+    return (arg.forceShowHidden || showHiddenArchaeologists) && !showOnlySelectedArchaeologists
       ? [...filteredSorted, ...hiddenArchaeologists]
       : filteredSorted;
   };

--- a/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
+++ b/src/features/embalm/stepContent/steps/SelectArchaeologists.tsx
@@ -22,14 +22,12 @@ import { useLoadArchaeologists } from '../hooks/useLoadArchaeologists';
 import { toggleShowHiddenArchaeologists } from 'store/archaeologistList/actions';
 
 interface SelectArchaeologistsProps {
-  hideHeader?: boolean;
-  showDial?: boolean;
+  isArchaeologistsDashboard?: boolean;
   defaultPageSize?: number;
 }
 
 export function SelectArchaeologists({
-  hideHeader = false,
-  showDial = false,
+  isArchaeologistsDashboard = false,
   defaultPageSize = 10,
 }: SelectArchaeologistsProps) {
   const outerLimit = 1;
@@ -46,9 +44,13 @@ export function SelectArchaeologists({
   const [resurrectionTimeEdit, setResurrectionTimeEdit] = useState<boolean>(false);
   const [paginationSize, setPaginationSize] = useState<number>(defaultPageSize);
 
+  const visibleArchaeologists = archaeologistListVisible({
+    forceShowHidden: isArchaeologistsDashboard,
+  });
+
   const { currentPage, setCurrentPage, pagesCount, pages, pageSize, setPageSize, offset } =
     usePagination({
-      total: archaeologistListVisible().length,
+      total: visibleArchaeologists.length,
       initialState: { currentPage: 1, pageSize: defaultPageSize },
       limits: {
         outer: outerLimit,
@@ -56,7 +58,7 @@ export function SelectArchaeologists({
       },
     });
 
-  const paginatedArchaeologist = archaeologistListVisible().slice(offset, offset + pageSize);
+  const paginatedArchaeologists = visibleArchaeologists.slice(offset, offset + pageSize);
   const resurrectionDate = new Date(resurrection);
 
   const handlePageChange = (nextPage: number): void => {
@@ -78,7 +80,7 @@ export function SelectArchaeologists({
       direction="column"
       width="100%"
     >
-      {!hideHeader ?? <Heading>Archaeologists</Heading>}
+      {!isArchaeologistsDashboard ?? <Heading>Archaeologists</Heading>}
       <Text
         mt="4"
         fontSize="lg"
@@ -132,8 +134,9 @@ export function SelectArchaeologists({
         >
           <VStack>
             <ArchaeologistList
-              paginatedArchaeologist={paginatedArchaeologist}
-              showDial={showDial}
+              paginatedArchaeologist={paginatedArchaeologists}
+              totalCount={visibleArchaeologists.length}
+              showDial={isArchaeologistsDashboard}
             />
             <Box w={'100%'}>
               <Flex justifyContent={'space-between'}>
@@ -248,7 +251,7 @@ export function SelectArchaeologists({
                     dispatch(toggleShowHiddenArchaeologists());
                   }}
                 >
-                  {showHiddenArchaeologists ? '(hide)' : '(show)'}
+                  {isArchaeologistsDashboard ? '' : showHiddenArchaeologists ? '(hide)' : '(show)'}
                 </Text>
               </HStack>
             ) : (

--- a/src/pages/ArchaeologistsPage.tsx
+++ b/src/pages/ArchaeologistsPage.tsx
@@ -24,10 +24,7 @@ export function ArchaeologistsPage() {
       >
         Archaeologists
       </Heading>
-      <SelectArchaeologists
-        hideHeader
-        showDial
-      />
+      <SelectArchaeologists isArchaeologistsDashboard />
     </Flex>
   );
 }


### PR DESCRIPTION
On main archaeologists page, show all online archs, irrespective of applied filters.

Existing UI indicating that an arch is ineligible is still present.

Show/hide toggle is removed, since it's meaningless now. But the `X ineligible` text remains.