### PR TITLE
Replace Date.now() with block timestamps

### DIFF
--- a/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
@@ -22,6 +22,7 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
   const dispatch = useDispatch();
   const { selectedArchaeologists, resurrection } = useSelector(x => x.embalmState);
   const { showOnlySelectedArchaeologists } = useSelector(x => x.archaeologistListState);
+  const { timestampMs } = useSelector(x => x.appState);
 
   function toggleShowOnlySelected() {
     dispatch(setShowSelectedArchaeologists(!showOnlySelectedArchaeologists));
@@ -32,9 +33,10 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
     () =>
       calculateProjectedDiggingFees(
         selectedArchaeologists.map(a => a.profile.minimumDiggingFeePerSecond),
-        resurrection
+        resurrection,
+        timestampMs
       ),
-    [resurrection, selectedArchaeologists]
+    [resurrection, selectedArchaeologists, timestampMs]
   );
 
   return (

--- a/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
@@ -39,14 +39,15 @@ export function ArchaeologistListItem({
   const rowTextColor = isSelected ? (archaeologist.exception ? '' : 'brand.950') : '';
 
   const resurrectionTime = useSelector(s => s.embalmState.resurrection);
+  const { timestampMs } = useSelector(s => s.appState);
 
   const diggingFees = useMemo(() => {
-    const nowSec = Math.floor(Date.now() / 1000);
+    const nowSec = Math.floor(timestampMs / 1000);
     const resurrectionTimeSec = Math.floor(resurrectionTime / 1000);
     return resurrectionTimeSec > nowSec
       ? archaeologist.profile.minimumDiggingFeePerSecond.mul(resurrectionTimeSec - nowSec)
       : null;
-  }, [archaeologist.profile.minimumDiggingFeePerSecond, resurrectionTime]);
+  }, [archaeologist.profile.minimumDiggingFeePerSecond, resurrectionTime, timestampMs]);
 
   const { data: ensName } = useEnsName({
     address: archaeologist.profile.archAddress as `0x${string}`,

--- a/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
+++ b/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
@@ -11,10 +11,12 @@ export function SarcophagusSummaryFees() {
   const { uploadPrice, selectedArchaeologists, resurrection } = useSelector(x => x.embalmState);
   const protocolFeeBasePercentage = useGetProtocolFeeAmount();
   const { balance } = useSarcoBalance();
+  const { timestampMs } = useSelector(x => x.appState);
 
   const { formattedTotalDiggingFees, totalDiggingFees, protocolFee } = getTotalFeesInSarco(
     resurrection,
     selectedArchaeologists.map(a => a.profile.minimumDiggingFeePerSecond),
+    timestampMs,
     protocolFeeBasePercentage
   );
 

--- a/src/features/embalm/stepContent/components/SetResurrection.tsx
+++ b/src/features/embalm/stepContent/components/SetResurrection.tsx
@@ -1,6 +1,7 @@
 import { Button, Flex, FlexProps, forwardRef, HStack, Text, VStack } from '@chakra-ui/react';
 import { DatePicker } from 'components/DatePicker';
 import { Radio } from 'components/Radio';
+import { useSelector } from 'store/index';
 import { useSetResurrection } from '../hooks/useSetResurrection';
 
 export enum ResurrectionRadioValue {
@@ -11,6 +12,7 @@ export enum ResurrectionRadioValue {
 
 export function SetResurrection({ ...rest }: FlexProps) {
   const options = Object.values(ResurrectionRadioValue);
+  const { timestampMs } = useSelector(x => x.appState);
 
   const {
     error,
@@ -65,14 +67,14 @@ export function SetResurrection({ ...rest }: FlexProps) {
               onChange={handleCustomDateChange}
               onInputClick={handleCustomDateClick}
               showTimeSelect
-              minDate={new Date()}
+              minDate={new Date(timestampMs)}
               showPopperArrow={false}
               timeIntervals={30}
               timeCaption="Time"
               timeFormat="hh:mma"
               dateFormat="MM.dd.yyyy hh:mma"
               fixedHeight
-              filterTime={date => new Date().getTime() < date.getTime()}
+              filterTime={date => timestampMs < date.getTime()}
               customInput={<CustomResurrectionButton />}
             />
           </Radio>

--- a/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
+++ b/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
@@ -26,6 +26,7 @@ export function useArchaeologistList() {
   const onlineArchaeologists = archaeologists.filter(a => a.isOnline);
 
   const resurrectionTimeMs = useSelector(s => s.embalmState.resurrection);
+  const { timestampMs } = useSelector(s => s.appState);
 
   // The archaeologist is not hidden out if:
   //  - resurrection time has been set further than the arch's max resurrection time
@@ -41,7 +42,7 @@ export function useArchaeologistList() {
     }
 
     const maxRewrapIntervalMs = a.profile.maximumRewrapInterval.toNumber() * 1000;
-    const resurrectionIntervalMs = resurrectionTimeMs - Date.now();
+    const resurrectionIntervalMs = resurrectionTimeMs - timestampMs;
 
     const estimatedCurse = !resurrectionTimeMs
       ? ethers.constants.Zero

--- a/src/features/embalm/stepContent/hooks/useBundlrSession.ts
+++ b/src/features/embalm/stepContent/hooks/useBundlrSession.ts
@@ -2,6 +2,7 @@ import { WebBundlr } from '@bundlr-network/client';
 import { useToast } from '@chakra-ui/react';
 import { InjectedEthereumSigner } from 'arbundles/src/signing';
 import { ethers } from 'ethers';
+import { useNetworkConfig } from 'lib/config';
 import {
   connectFailure,
   connectStart,
@@ -12,7 +13,6 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { connect, disconnect as disconnectBundlr, setBundlr } from 'store/bundlr/actions';
 import { useDispatch, useSelector } from 'store/index';
 import { useAccount } from 'wagmi';
-import { useNetworkConfig } from 'lib/config';
 import { hardhatChainId } from '../../../../lib/config/hardhat';
 
 export function useBundlrSession() {

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useArchaeologistSignatureNegotiation.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useArchaeologistSignatureNegotiation.ts
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from '../../../../../store';
 import { NEGOTIATION_SIGNATURE_STREAM } from '../../../../../lib/config/node_config';
 import { ArchaeologistExceptionCode, SarcophagusValidationError } from 'types';
 import {
+  getCurrentTimeSec,
   getLowestResurrectionTime,
   getLowestRewrapInterval,
 } from '../../../../../lib/utils/helpers';
@@ -12,6 +13,7 @@ import { CreateSarcophagusContext } from '../../context/CreateSarcophagusContext
 import { useDialArchaeologists } from './useDialArchaeologists';
 import { CancelCreateToken } from './useCreateSarcophagus';
 import * as Sentry from '@sentry/react';
+import { useProvider } from 'wagmi';
 
 interface ArchaeologistSignatureNegotiationParams {
   maxRewrapInterval: number;
@@ -34,6 +36,8 @@ export function useArchaeologistSignatureNegotiation() {
     useContext(CreateSarcophagusContext);
 
   const { dialArchaeologist } = useDialArchaeologists();
+
+  const provider = useProvider();
 
   function processDeclinedSignatureCode(
     code: SarcophagusValidationError,
@@ -59,7 +63,7 @@ export function useArchaeologistSignatureNegotiation() {
       const lowestRewrapInterval = getLowestRewrapInterval(selectedArchaeologists);
       const lowestResurrectionTime = getLowestResurrectionTime(selectedArchaeologists);
 
-      const negotiationTimestamp = Date.now();
+      const negotiationTimestamp = (await getCurrentTimeSec(provider)) * 1000;
       setNegotiationTimestamp(negotiationTimestamp);
 
       const archaeologistSignatures = new Map<string, string>([]);
@@ -156,9 +160,10 @@ export function useArchaeologistSignatureNegotiation() {
       setArchaeologistSignatures(archaeologistSignatures);
     },
     [
-      dispatch,
-      selectedArchaeologists,
       dialArchaeologist,
+      dispatch,
+      provider,
+      selectedArchaeologists,
       setArchaeologistPublicKeys,
       setArchaeologistSignatures,
       setNegotiationTimestamp,

--- a/src/features/embalm/stepContent/hooks/useSarcophagusParameters.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcophagusParameters.ts
@@ -36,6 +36,7 @@ export const useSarcophagusParameters = () => {
     requiredArchaeologists,
   } = useSelector(x => x.embalmState);
   const { balance } = useSelector(x => x.bundlrState);
+  const { timestampMs } = useSelector(x => x.appState);
 
   const { getStatus } = useStepNavigator();
   const { chainId } = useNetworkConfig();
@@ -46,9 +47,9 @@ export const useSarcophagusParameters = () => {
 
   const resurrectionTimeError = !resurrection
     ? 'Please set a resurrection time'
-    : resurrection > maxRewrapIntervalMs + Date.now()
+    : resurrection > maxRewrapIntervalMs + timestampMs
     ? 'The resurrection time you have selected is beyond the maximum rewrap interval of your selected archaeologists'
-    : resurrection - minimumResurrection < Date.now() && resurrection !== 0
+    : resurrection - minimumResurrection < timestampMs && resurrection !== 0
     ? `Resurrection must be ${moment
         .duration(minimumResurrection)
         .humanize()} or more in the future.`

--- a/src/features/embalm/stepContent/hooks/useSetResurrection.ts
+++ b/src/features/embalm/stepContent/hooks/useSetResurrection.ts
@@ -20,6 +20,7 @@ export function useSetResurrection() {
     resurrectionRadioValue: radioValue,
     customResurrectionDate,
   } = useSelector(x => x.embalmState);
+  const { timestampMs } = useSelector(x => x.appState);
 
   // Although resurrection in ms is already stored in global state, we need another state to make it
   // easier to display the value in the DatePicker. Resurrection and CustomResurrectionDate will often be
@@ -58,18 +59,18 @@ export function useSetResurrection() {
       } else {
         const [days] = radioValue === '' ? '0' : radioValue.split(' ');
         const intervalMs = parseInt(days) * 24 * 60 * 60 * 1000;
-        dispatch(setResurrection(Date.now() + intervalMs));
+        dispatch(setResurrection(timestampMs + intervalMs));
       }
     } else {
       if (customResurrectionDate) {
         dispatch(setResurrection(customResurrectionDate.getTime()));
       }
     }
-  }, [dispatch, radioValue, customResurrectionDate]);
+  }, [customResurrectionDate, dispatch, radioValue, timestampMs]);
 
   // Updates the error if the resurrection time is invalid
   useEffect(() => {
-    if (resurrection - minimumResurrection < Date.now() && resurrection !== 0) {
+    if (resurrection - minimumResurrection < timestampMs && resurrection !== 0) {
       setError(
         `Resurrection must be ${moment
           .duration(minimumResurrection)
@@ -78,7 +79,7 @@ export function useSetResurrection() {
     } else {
       setError(null);
     }
-  }, [resurrection]);
+  }, [resurrection, timestampMs]);
 
   return {
     error,

--- a/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
+++ b/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
@@ -36,6 +36,7 @@ export function CreateSarcophagus() {
   const { addPeerDiscoveryEventListener } = useBootLibp2pNode(20_000);
   const globalLibp2pNode = useSelector(s => s.appState.libp2pNode);
   const { cancelCreateToken } = useSelector(s => s.embalmState);
+  const { timestampMs } = useSelector(x => x.appState);
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { allowance } = useAllowance();
@@ -141,6 +142,7 @@ export function CreateSarcophagus() {
   const { totalDiggingFees, protocolFee } = getTotalFeesInSarco(
     resurrection,
     selectedArchaeologists.map(a => a.profile.minimumDiggingFeePerSecond),
+    timestampMs,
     protocolFeeBasePercentage
   );
 

--- a/src/features/embalm/stepNavigator/hooks/useSetStatuses.ts
+++ b/src/features/embalm/stepNavigator/hooks/useSetStatuses.ts
@@ -50,13 +50,13 @@ export function useSetStatuses() {
     stepStatuses,
   } = useSelector(x => x.embalmState);
   const { isConnected: isBundlrConnected } = useSelector(x => x.bundlrState);
+  const { timestampMs } = useSelector(x => x.appState);
   const { uploadPrice } = useUploadPrice();
   const { balance } = useGetBalance();
   const { isConnected: isWalletConnected } = useAccount();
   const { chain } = useNetwork();
 
   // Need to declare this here to prevent infinite effect loop
-  const nameSarcophagusStatus = stepStatuses[Step.NameSarcophagus];
   const fundBundlrStatus = stepStatuses[Step.FundBundlr];
   const requiredArchaeologistsStatus = stepStatuses[Step.RequiredArchaeologists];
   const selectedArchaeologistsStatus = stepStatuses[Step.SelectArchaeologists];
@@ -64,7 +64,7 @@ export function useSetStatuses() {
   function nameSarcophagusEffect() {
     // Change status to started if any input element has been completed
     const validName = name.trim().length > 0;
-    const validResurrection = resurrection - minimumResurrection > Date.now();
+    const validResurrection = resurrection - minimumResurrection > timestampMs;
 
     if (validName && validResurrection) {
       dispatch(updateStepStatus(Step.NameSarcophagus, StepStatus.Complete));
@@ -127,7 +127,7 @@ export function useSetStatuses() {
     }
   }
 
-  useEffect(nameSarcophagusEffect, [dispatch, name, nameSarcophagusStatus, resurrection]);
+  useEffect(nameSarcophagusEffect, [dispatch, name, resurrection, timestampMs]);
   useEffect(uploadPayloadEffect, [dispatch, file]);
   useEffect(fundBundlrEffect, [
     balance,

--- a/src/features/sarcophagi/components/Claim.tsx
+++ b/src/features/sarcophagi/components/Claim.tsx
@@ -7,6 +7,7 @@ import { useGetSarcophagus } from 'hooks/viewStateFacet';
 import { buildResurrectionDateString } from 'lib/utils/helpers';
 import { useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useSelector } from 'store/index';
 import { useQuery } from '../../../hooks/useQuery';
 
 export function Claim() {
@@ -16,8 +17,10 @@ export function Claim() {
   const [privateKey, setPrivateKey] = useState(query.get('pk') || '');
   const [resurrectError, setResurrectError] = useState('');
   const { sarcophagus, isLoading: isLoadingSarcophagus } = useGetSarcophagus(id);
+  const { timestampMs } = useSelector(x => x.appState);
   const resurrectionString = buildResurrectionDateString(
-    sarcophagus?.resurrectionTime || BigNumber.from(0)
+    sarcophagus?.resurrectionTime || BigNumber.from(0),
+    timestampMs
   );
 
   const {

--- a/src/features/sarcophagi/components/Details.tsx
+++ b/src/features/sarcophagi/components/Details.tsx
@@ -4,6 +4,7 @@ import { useGetSarcophagus } from 'hooks/viewStateFacet';
 import { useGetEmbalmerCanClean } from 'hooks/viewStateFacet/useGetEmbalmerCanClean';
 import { buildResurrectionDateString } from 'lib/utils/helpers';
 import { NavLink, useParams } from 'react-router-dom';
+import { useSelector } from 'store/index';
 import { SarcophagusState } from 'types';
 import { useAccount } from 'wagmi';
 import { BuryButton } from './BuryButton';
@@ -16,8 +17,10 @@ export function Details() {
   const { id } = useParams();
   const { sarcophagus } = useGetSarcophagus(id);
   const { address } = useAccount();
+  const { timestampMs } = useSelector(x => x.appState);
   const resurrectionString = buildResurrectionDateString(
-    sarcophagus?.resurrectionTime || BigNumber.from(0)
+    sarcophagus?.resurrectionTime || BigNumber.from(0),
+    timestampMs
   );
 
   // TODO: Find a way to recalculate canWrapOrBury when bury happens

--- a/src/features/sarcophagi/components/SarcoTableRow.tsx
+++ b/src/features/sarcophagi/components/SarcoTableRow.tsx
@@ -7,6 +7,7 @@ import { useGetEmbalmerCanClean } from 'hooks/viewStateFacet/useGetEmbalmerCanCl
 import { buildResurrectionDateString } from 'lib/utils/helpers';
 import { useEffect, useState } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
+import { useSelector } from 'store/index';
 import { Sarcophagus, SarcophagusState } from 'types';
 import { useAccount } from 'wagmi';
 import { cleanTooltip } from './CleanButton';
@@ -35,6 +36,7 @@ export function SarcoTableRow({
 }: SarcophagusTableRowProps) {
   const { address } = useAccount();
   const navigate = useNavigate();
+  const { timestampMs } = useSelector(x => x.appState);
 
   const [resurrectionString, setResurrectionString] = useState('');
 
@@ -103,18 +105,20 @@ export function SarcoTableRow({
 
   // Updates the resurrection date string on an interval
   useEffect(() => {
-    setResurrectionString(buildResurrectionDateString(sarco.resurrectionTime || BigNumber.from(0)));
+    setResurrectionString(
+      buildResurrectionDateString(sarco.resurrectionTime || BigNumber.from(0), timestampMs)
+    );
 
     const intervalId = setInterval(() => {
       setResurrectionString(
-        buildResurrectionDateString(sarco.resurrectionTime || BigNumber.from(0))
+        buildResurrectionDateString(sarco.resurrectionTime || BigNumber.from(0), timestampMs)
       );
     }, dateCalculationInterval);
 
     return () => {
       clearInterval(intervalId);
     };
-  }, [dateCalculationInterval, sarco.resurrectionTime]);
+  }, [dateCalculationInterval, sarco.resurrectionTime, timestampMs]);
 
   return (
     <Tr>

--- a/src/features/sarcophagi/hooks/useGetSarcophagi.ts
+++ b/src/features/sarcophagi/hooks/useGetSarcophagi.ts
@@ -3,6 +3,7 @@ import { useGetGracePeriod } from 'hooks/viewStateFacet/useGetGracePeriod';
 import { useNetworkConfig } from 'lib/config';
 import { getSarcophagusState } from 'lib/utils/getSarcophagusState';
 import { useEffect, useState } from 'react';
+import { useSelector } from 'store/index';
 import { Sarcophagus, SarcophagusResponseContract } from 'types';
 import { useContractReads } from 'wagmi';
 
@@ -13,6 +14,7 @@ export function useGetSarcophagi(sarcoIds: string[], refetchInterval = 60_000): 
   const networkConfig = useNetworkConfig();
   const gracePeriod = useGetGracePeriod();
   const [sarcophagiResponse, setSarcophagiResponse] = useState<SarcophagusResponseContract[]>([]);
+  const { timestampMs } = useSelector(x => x.appState);
 
   const { data, refetch } = useContractReads({
     contracts: sarcoIds.map(id => ({
@@ -41,7 +43,7 @@ export function useGetSarcophagi(sarcoIds: string[], refetchInterval = 60_000): 
   if (!data) return [];
   const sarcophagi = sarcophagiResponse.map((sarcoResponse, index) => ({
     ...sarcoResponse,
-    state: getSarcophagusState(sarcoResponse, gracePeriod),
+    state: getSarcophagusState(sarcoResponse, gracePeriod, timestampMs),
     id: sarcoIds?.[index] || '',
   }));
 

--- a/src/hooks/useTimestampMs.ts
+++ b/src/hooks/useTimestampMs.ts
@@ -1,0 +1,19 @@
+import { useCallback, useEffect } from 'react';
+import { useDispatch } from 'store/index';
+import { setTimestampMs } from 'store/app/actions';
+import { useProvider } from 'wagmi';
+
+export function useTimestampMs() {
+  const provider = useProvider();
+  const dispatch = useDispatch();
+
+  const getTimestampMs = useCallback(async () => {
+    const blockNumber = await provider.getBlockNumber();
+    const block = await provider.getBlock(blockNumber);
+    dispatch(setTimestampMs(block.timestamp * 1000));
+  }, [dispatch, provider]);
+
+  useEffect(() => {
+    getTimestampMs();
+  }, [getTimestampMs]);
+}

--- a/src/hooks/viewStateFacet/useGetEmbalmerCanClean.ts
+++ b/src/hooks/viewStateFacet/useGetEmbalmerCanClean.ts
@@ -1,6 +1,7 @@
 import { ViewStateFacet__factory } from '@sarcophagus-org/sarcophagus-v2-contracts';
 import { BigNumber } from 'ethers';
 import { useNetworkConfig } from 'lib/config';
+import { useSelector } from 'store/index';
 import { Sarcophagus } from 'types';
 import { useAccount, useContractRead } from 'wagmi';
 import { useGetGracePeriod } from './useGetGracePeriod';
@@ -12,6 +13,7 @@ import { useGetGracePeriod } from './useGetGracePeriod';
 export function useGetEmbalmerCanClean(sarcophagus: Sarcophagus | undefined): boolean {
   const networkConfig = useNetworkConfig();
   const gracePeriod = useGetGracePeriod();
+  const { timestampMs } = useSelector(x => x.appState);
 
   const { data } = useContractRead({
     address: networkConfig.diamondDeployAddress,
@@ -27,7 +29,7 @@ export function useGetEmbalmerCanClean(sarcophagus: Sarcophagus | undefined): bo
 
   const sarcoResurrectionTime = Number.parseInt(sarcophagus.resurrectionTime.toString());
   const cleanWindow = Number.parseInt((data as BigNumber).toString());
-  const nowSeconds = Math.trunc(Date.now() / 1000);
+  const nowSeconds = Math.trunc(timestampMs / 1000);
 
   const sarcoGracePeriod = sarcoResurrectionTime + gracePeriod;
   const isWithinCleanWindow =

--- a/src/hooks/viewStateFacet/useGetSarcophagus.ts
+++ b/src/hooks/viewStateFacet/useGetSarcophagus.ts
@@ -2,6 +2,7 @@ import { ViewStateFacet__factory } from '@sarcophagus-org/sarcophagus-v2-contrac
 import { ethers } from 'ethers';
 import { useNetworkConfig } from 'lib/config';
 import { getSarcophagusState } from 'lib/utils/getSarcophagusState';
+import { useSelector } from 'store/index';
 import { Sarcophagus, SarcophagusResponseContract } from 'types';
 import { useContractRead } from 'wagmi';
 import { useGetGracePeriod } from './useGetGracePeriod';
@@ -9,6 +10,7 @@ import { useGetGracePeriod } from './useGetGracePeriod';
 export function useGetSarcophagus(sarcoId: string | undefined) {
   const networkConfig = useNetworkConfig();
   const gracePeriod = useGetGracePeriod();
+  const { timestampMs } = useSelector(x => x.appState);
 
   const { data, refetch, isLoading } = useContractRead({
     address: networkConfig.diamondDeployAddress,
@@ -23,7 +25,7 @@ export function useGetSarcophagus(sarcoId: string | undefined) {
     ? undefined
     : {
         ...sarcophagusResponse,
-        state: getSarcophagusState(sarcophagusResponse, gracePeriod),
+        state: getSarcophagusState(sarcophagusResponse, gracePeriod, timestampMs),
         id: sarcoId || '',
       };
 

--- a/src/lib/utils/getSarcophagusState.ts
+++ b/src/lib/utils/getSarcophagusState.ts
@@ -3,22 +3,23 @@ import { SarcophagusResponseContract, SarcophagusState } from 'types';
 
 export const getSarcophagusState = (
   sarco: SarcophagusResponseContract,
-  gracePeriod: number
+  gracePeriod: number,
+  timestampMs: number
 ): SarcophagusState => {
   if (sarco.resurrectionTime.eq(ethers.constants.Zero)) return SarcophagusState.DoesNotExist;
   if (sarco.resurrectionTime.eq(ethers.constants.MaxUint256)) return SarcophagusState.Buried;
   if (sarco.isCompromised) return SarcophagusState.Accused;
 
-  const nowSeconds = Math.trunc(Date.now() / 1000);
+  const timestampSec = Math.trunc(timestampMs / 1000);
 
-  const isPastGracePeriod = nowSeconds >= sarco.resurrectionTime.toNumber() + gracePeriod;
+  const isPastGracePeriod = timestampSec >= sarco.resurrectionTime.toNumber() + gracePeriod;
 
   if (sarco.publishedPrivateKeyCount >= sarco.threshold)
     return sarco.isCleaned ? SarcophagusState.CleanedResurrected : SarcophagusState.Resurrected;
 
   const withinGracePeriod =
-    nowSeconds >= sarco.resurrectionTime.toNumber() &&
-    nowSeconds < sarco.resurrectionTime.toNumber() + gracePeriod;
+    timestampSec >= sarco.resurrectionTime.toNumber() &&
+    timestampSec < sarco.resurrectionTime.toNumber() + gracePeriod;
 
   if (withinGracePeriod) return SarcophagusState.Resurrecting;
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,6 +19,7 @@ import { WalletDisconnectPage } from './WalletDisconnectPage';
 import { useBundlrSession } from 'features/embalm/stepContent/hooks/useBundlrSession';
 import { AccusePage } from './AccusePage';
 import { AdminDashBoardPage } from './AdminDashboardPage';
+import { useTimestampMs } from 'hooks/useTimestampMs';
 
 export enum RouteKey {
   ARCHEOLOGIST_PAGE,
@@ -135,10 +136,11 @@ export function Pages() {
 
   const { isConnected } = useAccount();
 
-  /**
-   * Handles Bundlr connection and disconnection
-   */
+  // Handles Bundlr connection and disconnection
   useBundlrSession();
+
+  // Globally stores the timestamp from the latest block
+  useTimestampMs();
 
   const { isSupportedChain } = useSupportedNetwork();
   const currentCommitHash = process.env.REACT_APP_COMMIT_REF;

--- a/src/store/StoreProvider.tsx
+++ b/src/store/StoreProvider.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useMemo } from 'react';
+import { useMemo, useReducer } from 'react';
 import { initialState, StoreContext, storeReducer } from '.';
 
 export function StoreProvider({ children }: { children: React.ReactNode }) {

--- a/src/store/app/actions.ts
+++ b/src/store/app/actions.ts
@@ -7,6 +7,7 @@ export enum ActionType {
   StartLoad = 'APP_START_LOAD',
   StopLoad = 'APP_STOP_LOAD',
   SetLibP2p = 'APP_SET_LIBP2P',
+  SetTimestampMs = 'APP_SET_TIMESTAMP_MS',
 }
 
 type AppPayload = {
@@ -18,6 +19,9 @@ type AppPayload = {
   };
   [ActionType.SetLibP2p]: {
     libp2pNode: Libp2p;
+  };
+  [ActionType.SetTimestampMs]: {
+    timestampMs: number;
   };
 };
 
@@ -44,6 +48,15 @@ export function setLibp2p(libp2pNode: Libp2p): AppActions {
     type: ActionType.SetLibP2p,
     payload: {
       libp2pNode,
+    },
+  };
+}
+
+export function setTimestampMs(timestampMs: number): AppActions {
+  return {
+    type: ActionType.SetTimestampMs,
+    payload: {
+      timestampMs,
     },
   };
 }

--- a/src/store/app/reducer.ts
+++ b/src/store/app/reducer.ts
@@ -5,11 +5,13 @@ import { ActionType } from './actions';
 export interface AppState {
   isLoading: boolean;
   libp2pNode: Libp2p | null;
+  timestampMs: number;
 }
 
 export const appInitialState: AppState = {
   isLoading: false,
   libp2pNode: null,
+  timestampMs: 0,
 };
 
 export function appReducer(state: AppState, action: Actions): AppState {
@@ -22,6 +24,9 @@ export function appReducer(state: AppState, action: Actions): AppState {
     }
     case ActionType.SetLibP2p: {
       return { ...state, libp2pNode: action.payload.libp2pNode };
+    }
+    case ActionType.SetTimestampMs: {
+      return { ...state, timestampMs: action.payload.timestampMs };
     }
 
     default:


### PR DESCRIPTION
## Replace Date.now() with block timestamps

Replaces all relevant instances of `Date.now()` in the web app with the latest block timestamp from ethers.

### Example
```
const blockNumber = await provider.getBlockNumber();
const block = await provider.getBlock(blockNumber);
const timestampSec = block.timestamp
```

### Approach 
Retrieving the timestamp is an async call, which means the best way to handle it is to store it in state. The `timestampMs` is stored in global app state and may be accessed from anywhere in the app. Storing it globally keeps us from having to create a new state for each instance that it is used. Keep in mind that it represents the time when the component loaded, it will not refresh itself. The timestamp may be accessed using the `useSelector` hook just like any other state value. 

From my observations, the offset between real time and the latest block timestamp is no more than 45 seconds or so. 

### Changes
There are several places throughout the app that used to use Date.now() to get the current time. 
- Calculating arch digging fees on the arch list
- Determining the min date on the resurrection date picker
- Calculating resurrection interval on the arch list
- During the arch negotiations
- Showing an error on the resurrection before sarco creation
- During the rewrap process
- And a few other places

### Testing 
The sarcophagus creation process is most affected by these changes, as well as the rewrap process. I have noticed no differences in my testing but they should continue to be rigorously tested. 