### PR TITLE
Sort by failures instead of cleanups

### DIFF
--- a/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
+++ b/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
@@ -116,7 +116,7 @@ export function useArchaeologistList() {
           } else if (archaeologistFilterSort.sortType === SortFilterType.UNWRAPS) {
             sortValue = arch.profile.successes;
           } else if (archaeologistFilterSort.sortType === SortFilterType.FAILS) {
-            sortValue = arch.profile.cleanups;
+            sortValue = arch.profile.failures;
           } else if (archaeologistFilterSort.sortType === SortFilterType.ADDRESS_SEARCH) {
             sortValue = arch.profile.archAddress;
           }


### PR DESCRIPTION
Changes the sort method for failures in the arch list to sort by failures instead of cleanups.