### PR TITLE
Hide missing info warning if fields are correct

### DIFF
--- a/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
+++ b/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
@@ -1,9 +1,12 @@
 import { Box, Flex, Text, VStack } from '@chakra-ui/react';
+import { useSarcophagusParameters } from '../hooks/useSarcophagusParameters';
 import { ReviewSarcophagusTable } from './ReviewSarcophagusTable';
 import { SarcophagusSummaryFees } from './SarcophagusSummaryFees';
 import { SummaryErrorIcon } from './SummaryErrorIcon';
 
 export function ReviewSarcophagus() {
+  const { sarcophagusParameters } = useSarcophagusParameters();
+
   return (
     <VStack
       align="left"
@@ -32,22 +35,24 @@ export function ReviewSarcophagus() {
             Sarcophagus Summary
           </Text>
         </Box>
-        <ReviewSarcophagusTable />
+        <ReviewSarcophagusTable sarcophagusParameters={sarcophagusParameters} />
         <SarcophagusSummaryFees />
-        <Flex
-          mt={3}
-          alignItems="center"
-        >
-          <SummaryErrorIcon />
-          <Text
-            variant="secondary"
-            fontSize="xs"
-            ml={2}
-            textAlign={'center'}
+        {sarcophagusParameters.some(p => p.error) && (
+          <Flex
+            mt={3}
+            alignItems="center"
           >
-            = missing information
-          </Text>
-        </Flex>
+            <SummaryErrorIcon />
+            <Text
+              variant="secondary"
+              fontSize="xs"
+              ml={2}
+              textAlign={'center'}
+            >
+              = missing information
+            </Text>
+          </Flex>
+        )}
       </Flex>
     </VStack>
   );

--- a/src/features/embalm/stepContent/components/ReviewSarcophagusTable.tsx
+++ b/src/features/embalm/stepContent/components/ReviewSarcophagusTable.tsx
@@ -1,11 +1,14 @@
 import { Flex, Table, Tbody, Td, Text, Th, Thead, Tr } from '@chakra-ui/react';
 import { useStepNavigator } from 'features/embalm/stepNavigator/hooks/useStepNavigator';
 import { maxSarcophagusNameLength } from 'lib/constants';
-import { useSarcophagusParameters } from '../hooks/useSarcophagusParameters';
+import { SarcophagusParameter } from '../hooks/useSarcophagusParameters';
 import { SummaryErrorIcon } from './SummaryErrorIcon';
 
-export function ReviewSarcophagusTable() {
-  const { sarcophagusParameters } = useSarcophagusParameters();
+interface ReviewSarcophagusTableProps {
+  sarcophagusParameters: SarcophagusParameter[];
+}
+
+export function ReviewSarcophagusTable({ sarcophagusParameters }: ReviewSarcophagusTableProps) {
   const { selectStep } = useStepNavigator();
   return (
     <Table


### PR DESCRIPTION
Hides the missing info warning when all fields are correct.

### With errors
![image](https://user-images.githubusercontent.com/34484576/225933158-bda6d1ad-9f50-4845-8d51-ed415784d222.png)

### Without errors
![image](https://user-images.githubusercontent.com/34484576/225933250-78f748a9-b01e-4e7f-a9ed-de752c9975e2.png)
