### PR TITLE
Fix admin dashboard eth logs limit

### DIFF
--- a/src/features/sarcophagi/hooks/useSarcophagusCount.ts
+++ b/src/features/sarcophagi/hooks/useSarcophagusCount.ts
@@ -1,0 +1,80 @@
+import { EmbalmerFacet__factory } from '@sarcophagus-org/sarcophagus-v2-contracts';
+import { useNetworkConfig } from 'lib/config';
+import {
+  getSarcophagusCountFromLocalStorage,
+  saveSarcophagusCountToLocalStorage,
+} from 'lib/utils/sarcohpagusCountLocalStorage';
+import { getBlockNumberLocalStorageKey } from 'lib/utils/storeDeploymentBlockNumber';
+import { useCallback, useState } from 'react';
+import { useProvider } from 'wagmi';
+
+const useSarcophagusCount = (refreshSarcophagusCountMs: number = 5 * 60 * 1000) => {
+  const networkConfig = useNetworkConfig();
+  const provider = useProvider();
+  const [sarcophagusCount, setSarcophagusCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [currentBlock, setCurrentBlock] = useState(0);
+  const [blockCount, setBlockCount] = useState(0);
+
+  // Generate the localStorage key for the current network and contract address
+  const sarcophagusCountLocalStorageKey = `sarcophagusCount_${networkConfig.chainId}_${networkConfig.diamondDeployAddress}`;
+
+  // Main function to fetch events and calculate sarcophagus count
+  const fetchEvents = useCallback(async () => {
+    setIsLoading(true);
+
+    // Attempt to retrieve the count from localStorage and verify if it's still valid
+    const countData = getSarcophagusCountFromLocalStorage(sarcophagusCountLocalStorageKey);
+    if (countData && Date.now() - countData.timestamp < refreshSarcophagusCountMs) {
+      setSarcophagusCount(countData.count);
+      setIsLoading(false);
+      return;
+    }
+
+    // Fetch 'CreateSarcophagus' events within a given range of blocks
+    const fetchEventsInRange = async (fromBlock: number, toBlock: number): Promise<Event[]> => {
+      const contract = EmbalmerFacet__factory.connect(networkConfig.diamondDeployAddress, provider);
+      return contract.queryFilter('CreateSarcophagus', fromBlock, toBlock);
+    };
+
+    try {
+      const chunkSize = 10000;
+      const blockNumberLocalStorageKey = getBlockNumberLocalStorageKey(networkConfig);
+      const storedDeploymentBlockNumber = localStorage.getItem(blockNumberLocalStorageKey);
+      if (!storedDeploymentBlockNumber)
+        throw new Error('Contract deployment block number not found in local storage.');
+
+      const fromBlock = parseInt(storedDeploymentBlockNumber, 10);
+      const toBlock = await provider.getBlockNumber();
+      setBlockCount(toBlock - fromBlock);
+
+      // Iterate through blocks in chunks, fetching events and updating progress
+      let events: Event[] = [];
+      for (let startBlock = fromBlock; startBlock <= toBlock; startBlock += chunkSize) {
+        const endBlock = Math.min(startBlock + chunkSize - 1, toBlock);
+        const chunkEvents = await fetchEventsInRange(startBlock, endBlock);
+        events = events.concat(chunkEvents);
+        setCurrentBlock(startBlock - fromBlock);
+      }
+
+      // Update the sarcophagus count and save it to localStorage
+      setSarcophagusCount(events.length);
+      saveSarcophagusCountToLocalStorage(sarcophagusCountLocalStorageKey, events.length);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [networkConfig, provider, refreshSarcophagusCountMs, sarcophagusCountLocalStorageKey]);
+
+  return {
+    sarcophagusCount,
+    isLoading,
+    currentBlock,
+    blockCount,
+    fetchEvents,
+    sarcophagusCountLocalStorageKey,
+  };
+};
+
+export default useSarcophagusCount;

--- a/src/lib/config/goerli.ts
+++ b/src/lib/config/goerli.ts
@@ -7,7 +7,7 @@ export const goerliNetworkConfig: NetworkConfig = {
   sarcoTokenAddress: '0x4633b43990b41B57b3678c6F3Ac35bA75C3D8436',
   diamondDeployAddress: '0x96e6192eeaf7bb308f79fb5017a9085754b9e12a',
   etherscanApiUrl: 'https://api-goerli.etherscan.io/api',
-  etherscanApiKey: '',
+  etherscanApiKey: process.env.REACT_APP_ETHERSCAN_API_KEY ?? '',
   explorerUrl: 'https://goerli.etherscan.io/',
   bundlr: {
     currencyName: 'ethereum',

--- a/src/lib/utils/sarcohpagusCountLocalStorage.ts
+++ b/src/lib/utils/sarcohpagusCountLocalStorage.ts
@@ -1,0 +1,17 @@
+export const getSarcophagusCountFromLocalStorage = (
+  localStorageKey: string
+): { count: number; timestamp: number } | null => {
+  const data = localStorage.getItem(localStorageKey);
+  if (!data) return null;
+  return JSON.parse(data);
+};
+
+export const saveSarcophagusCountToLocalStorage = (
+  localStorageKey: string,
+  count: number
+): void => {
+  // Usually we would use the block timestamp in place of Date.now() but that is not necessary in
+  // this case
+  const data = { count, timestamp: Date.now() };
+  localStorage.setItem(localStorageKey, JSON.stringify(data));
+};

--- a/src/lib/utils/storeDeploymentBlockNumber.ts
+++ b/src/lib/utils/storeDeploymentBlockNumber.ts
@@ -1,0 +1,54 @@
+import { providers } from 'ethers';
+import { NetworkConfig } from 'lib/config/networkConfigType';
+
+async function getContractDeploymentBlockNumber(
+  provider: providers.Provider,
+  networkConfig: NetworkConfig
+): Promise<number> {
+  const code = await provider.getCode(networkConfig.diamondDeployAddress);
+
+  if (code === '0x') {
+    throw new Error('Contract not found at the provided address.');
+  }
+
+  const network = await provider.getNetwork();
+  const url = `https://api${
+    network.chainId === 1 ? '' : `-${network.name}`
+  }.etherscan.io/api?module=account&action=txlist&address=${
+    networkConfig.diamondDeployAddress
+  }&startblock=0&endblock=99999999&sort=asc&apikey=${networkConfig.etherscanApiKey}`;
+
+  const response = await fetch(url);
+  const data = await response.json();
+
+  if (data.status !== '1' || data.result.length === 0) {
+    throw new Error('Contract creation transaction not found.');
+  }
+
+  const txHash = data.result[0].hash;
+  const receipt = await provider.getTransactionReceipt(txHash);
+
+  if (!receipt) {
+    throw new Error('Contract deployment receipt not found.');
+  }
+
+  return receipt.blockNumber;
+}
+
+export function getBlockNumberLocalStorageKey(networkConfig: NetworkConfig) {
+  return `contractDeploymentBlockNumber_${networkConfig.chainId}_${networkConfig.diamondDeployAddress}`;
+}
+
+export async function storeDeploymentBlockNumber(
+  provider: providers.Provider,
+  networkConfig: NetworkConfig
+) {
+  const localStorageKey = getBlockNumberLocalStorageKey(networkConfig);
+
+  if (localStorage.getItem(localStorageKey)) {
+    return;
+  }
+
+  const blockNumber = await getContractDeploymentBlockNumber(provider, networkConfig);
+  localStorage.setItem(localStorageKey, blockNumber.toString());
+}


### PR DESCRIPTION
## Fix Admin Dashboard

The admin dashboard (http://localhost:3000/admin-dashboard) was throwing an error because it's querying events to get the number of sarcophagi that have been created. This count is limited to 10000. This PR fixes that problem.
 
### Notes
- Gets the number of `CreateSarcohpagus` events since the contract's deployment 
- Uses etherscan api to get the contract's deployment block. If an etherscan api key is not provided it will fall back to a public api key which may or may not work. 
- If etherscan api call to get block number fails, an error is logged and a default block number is used
- sarcophagi are queried in chunks of 10,000 and concatenated together 
- currently it takes 17 requests to get all sarcohpagi. This number will increase as time goes on 
- sarcohpagusCount is stored in localStorage and refreshes on re-render if 5 min has passed. 
- A refresh button was added to manually load the sarcophagusCount
- Getting all sarcophagi can take a minute or so

![image](https://user-images.githubusercontent.com/34484576/226747366-84ee5825-23ca-4636-a488-54cc2f4eb74f.png)
![image](https://user-images.githubusercontent.com/34484576/226747453-476b65f0-2fce-4ed3-ac1d-fb3017fab4cc.png)

