### PR TITLE
Fix dashboard rpc errors

### DIFF
--- a/src/features/sarcophagi/components/CleanButton.tsx
+++ b/src/features/sarcophagi/components/CleanButton.tsx
@@ -1,12 +1,14 @@
 import { Button, Tooltip } from '@chakra-ui/react';
 import { useCleanSarcophagus } from 'hooks/thirdPartyFacet/useCleanSarcophagus';
+import { useGetEmbalmerCanClean } from 'hooks/viewStateFacet/useGetEmbalmerCanClean';
 import { Sarcophagus } from 'types';
 
 export const cleanTooltip =
   'Claim bonds and digging fees from Archaeologists that did not participate in the unwrapping ceremony';
 
 export function CleanButton({ sarco }: { sarco: Sarcophagus }) {
-  const { clean, isCleaning, isError, mayFail } = useCleanSarcophagus(sarco.id);
+  const canEmbalmerClean = useGetEmbalmerCanClean(sarco);
+  const { clean, isCleaning, isError, mayFail } = useCleanSarcophagus(sarco.id, canEmbalmerClean);
 
   return (
     <>

--- a/src/features/sarcophagi/components/SarcoTableRow.tsx
+++ b/src/features/sarcophagi/components/SarcoTableRow.tsx
@@ -41,8 +41,8 @@ export function SarcoTableRow({
   const [resurrectionString, setResurrectionString] = useState('');
 
   // Payment for clean automatically goes to the current user
-  const { clean, isCleaning } = useCleanSarcophagus(sarco.id);
   const canEmbalmerClean = useGetEmbalmerCanClean(sarco);
+  const { clean, isCleaning } = useCleanSarcophagus(sarco.id, canEmbalmerClean);
 
   // If we ever decide to add a dashboard for archaeologists that case will need to be considered
   // here.

--- a/src/hooks/thirdPartyFacet/useCleanSarcophagus.ts
+++ b/src/hooks/thirdPartyFacet/useCleanSarcophagus.ts
@@ -5,13 +5,14 @@ import { useNetworkConfig } from 'lib/config';
 import { cleanFailure, cleanSuccess } from 'lib/utils/toast';
 import { useContractWrite, usePrepareContractWrite, useWaitForTransaction } from 'wagmi';
 
-export function useCleanSarcophagus(sarcoId: string) {
+export function useCleanSarcophagus(sarcoId: string, canEmbalmerClean: boolean) {
   const networkConfig = useNetworkConfig();
   const toast = useToast();
 
   const { config, isError: mayFail } = usePrepareContractWrite({
     address: networkConfig.diamondDeployAddress,
     abi: ThirdPartyFacet__factory.abi as Abi,
+    enabled: canEmbalmerClean,
     functionName: 'clean',
     args: [sarcoId],
   });


### PR DESCRIPTION
## Fix dashboard RPC errors 

Fixes the dashboard errors 
![image](https://user-images.githubusercontent.com/34484576/227250041-76ad0862-9fb5-4544-afb8-fe2e28eefaad.png)

### The Problem 
The dashboard has actions on each row that may directly call a contract function, one of those actions is clean. The dashboard uses the `useCleanSarcohpagus` hook. The problem is that the `useCleanSarcophagus` hook  uses a `usePrepareContractWrite` hook, which validates that the function would succeed. Obviously, this validation would fail if the sarcophagus in question cannot be cleaned. All we need to do is add the `canEmbalmerClean` boolean on the `enabled` field of the `usePrepareContractWrite` hook options so that the prepare hook is not trying to validate that it can succeed when it shouldn't.
```
  const { config, isError: mayFail } = usePrepareContractWrite({
    address: networkConfig.diamondDeployAddress,
    abi: ThirdPartyFacet__factory.abi as Abi,
    enabled: canEmbalmerClean,
    functionName: 'clean',
    args: [sarcoId],
  });
  ```