### PR TITLE
Fix dashboard height issue

### DIFF
--- a/src/features/sarcophagi/components/SarcoTable.tsx
+++ b/src/features/sarcophagi/components/SarcoTable.tsx
@@ -73,7 +73,6 @@ export function SarcoTable({ ids, isClaimTab }: SarcoTableProps) {
     <TableContainer
       overflowY="auto"
       h="100%"
-      minHeight="300px"
     >
       <Table
         variant="unstyled"

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -15,7 +15,7 @@ export function DashboardPage() {
         mb="75px"
         maxWidth="1200px"
         minWidth="800px"
-        minHeight="400px"
+        minHeight="360px"
       >
         <Sarcophagi />
       </Flex>


### PR DESCRIPTION
Fixes a height issue on the dashboard. The bottom sarcophagus was being hidden when the screen height was small. That issue is fixed. 
The actually sarcophagi component itself does still have a minHeight set on it but I lowered it to support even smaller screens. It's set so that at least 5 sarcophagi may be shown at a time. Any less and it just looks bad. A screen height of less than 600px may still experience some issues. 