### PR TITLE
Add curse fee updates to web app

### DIFF
--- a/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   useColorModeValue,
 } from '@chakra-ui/react';
+import { ethers } from 'ethers';
 import { calculateProjectedDiggingFees, formatSarco } from 'lib/utils/helpers';
 import { useMemo } from 'react';
 import { setShowSelectedArchaeologists } from 'store/archaeologistList/actions';
@@ -38,6 +39,10 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
       ),
     [resurrection, selectedArchaeologists, timestampMs]
   );
+
+  const curseFees = selectedArchaeologists.reduce((acc, archaeologist) => {
+    return acc.add(archaeologist.profile.curseFee);
+  }, ethers.constants.Zero);
 
   return (
     <Box mt={10}>
@@ -74,7 +79,7 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
         {resurrection ? (
           <HStack mr={2}>
             <Tooltip
-              label="This is how much SARCO it will cost you each time you rewrap your Sarchophagus"
+              label="This is how much SARCO it will cost you the next time you rewrap the Sarcophagus"
               placement="top"
             >
               <Icon as={InfoOutlineIcon}></Icon>
@@ -86,7 +91,7 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
                 variant="bold"
                 as="u"
               >
-                {formatSarco(diggingFees.toString())} SARCO
+                {formatSarco(diggingFees.add(curseFees).toString())} SARCO
               </Text>
             </Text>
             <Text

--- a/src/features/embalm/stepContent/components/ArchaeologistList.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistList.tsx
@@ -142,7 +142,7 @@ export function ArchaeologistList({
                           </Flex>
                         </Button>
                         <Tooltip
-                          label="Amount to be paid for each rewrap"
+                          label="Amount to be paid for the next rewrap"
                           placement="top"
                         >
                           <Icon

--- a/src/features/embalm/stepContent/components/MultiLineTooltip.tsx
+++ b/src/features/embalm/stepContent/components/MultiLineTooltip.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Tooltip, TooltipProps } from '@chakra-ui/react';
+
+interface MultiLineTooltipProps extends TooltipProps {
+  lines?: string[];
+}
+
+export function MultiLineTooltip({ lines, children, ...rest }: MultiLineTooltipProps) {
+  if (!lines || lines.length === 0) {
+    return <>{children}</>;
+  }
+
+  const tooltipContent = (
+    <>
+      {lines.map((line, index) => (
+        <React.Fragment key={index}>
+          {line}
+          {index < lines.length - 1 && <br />}
+        </React.Fragment>
+      ))}
+    </>
+  );
+
+  return (
+    <Tooltip
+      label={tooltipContent}
+      {...rest}
+    >
+      {children}
+    </Tooltip>
+  );
+}

--- a/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
+++ b/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
@@ -29,6 +29,8 @@ export function SarcophagusSummaryFees() {
     ? diggingFeesAndCurseFees.div(100 * protocolFeeBasePercentage)
     : BigNumber.from(0);
 
+  const totalFees = diggingFeesAndCurseFees.add(protocolFee);
+
   return (
     <Box
       py={4}
@@ -92,6 +94,13 @@ export function SarcophagusSummaryFees() {
             >
               {formatSarco(protocolFee.toString())} SARCO
             </Text>
+          </Flex>
+          <Flex
+            w="100%"
+            justifyContent="space-between"
+          >
+            <Text as="i">Total Fees</Text>
+            <Text as="i">{formatSarco(totalFees.toString())} SARCO</Text>
           </Flex>
           <Divider
             my={2}

--- a/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
+++ b/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
@@ -24,9 +24,10 @@ export function SarcophagusSummaryFees() {
     return acc.add(archaeologist.profile.curseFee);
   }, BigNumber.from(0));
 
-  const protocolFeeWithCurseFee = totalDiggingFees
-    .add(totalCurseFees)
-    .div(BigNumber.from(100 * protocolFeeBasePercentage));
+  const diggingFeesAndCurseFees = totalDiggingFees.add(totalCurseFees);
+  const protocolFee = diggingFeesAndCurseFees.gt(0)
+    ? diggingFeesAndCurseFees.div(100 * protocolFeeBasePercentage)
+    : BigNumber.from(0);
 
   return (
     <Box
@@ -38,7 +39,7 @@ export function SarcophagusSummaryFees() {
         px={6}
       >
         <Flex alignItems="center">
-          {balance?.lt(totalDiggingFees.add(protocolFeeWithCurseFee)) ? (
+          {balance?.lt(totalDiggingFees.add(protocolFee)) ? (
             <SummaryErrorIcon error={"You don't have enough SARCO to cover creation fees!"} />
           ) : (
             <Tooltip
@@ -89,7 +90,7 @@ export function SarcophagusSummaryFees() {
               variant="secondary"
               fontSize="xs"
             >
-              {formatSarco(protocolFeeWithCurseFee.toString())} SARCO
+              {formatSarco(protocolFee.toString())} SARCO
             </Text>
           </Flex>
           <Divider

--- a/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
+++ b/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
@@ -46,7 +46,9 @@ export function useArchaeologistList() {
 
     const estimatedCurse = !resurrectionTimeMs
       ? ethers.constants.Zero
-      : a.profile.minimumDiggingFeePerSecond.mul(Math.trunc(resurrectionIntervalMs / 1000));
+      : a.profile.minimumDiggingFeePerSecond
+          .mul(Math.trunc(resurrectionIntervalMs / 1000))
+          .add(a.profile.curseFee);
 
     if (resurrectionIntervalMs > maxRewrapIntervalMs) {
       a.hiddenReason = `The time interval to your resurrection time exceeds the maximum period this archaeologist is willing to be responsible for a Sarcophagus. Maximum interval: ~${Math.round(
@@ -55,7 +57,6 @@ export function useArchaeologistList() {
       return false;
     }
 
-    // TODO: also validate with curse fee once implemented
     if (estimatedCurse.gt(a.profile.freeBond)) {
       a.hiddenReason =
         'This archaeologist does not have enough in free bond to be responsible for your Sarcophagus for the length of time you have set.';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export interface ArchaeologistProfile {
   minimumDiggingFeePerSecond: BigNumber;
   peerId: string;
   successes: BigNumber;
+  curseFee: BigNumber;
 }
 
 export interface ArchaeologistEncryptedShard {


### PR DESCRIPTION
## Add curse fee updates to web app

Added the curse fee to the web app. 
- Added curse fee to the fees column in the arch list. Note that this will only show when a resurrection time is selected 
- Included curse fee in the calculation to determine which archs should be shown in the list 
- Added a tooltip to the fees line item to show digging fee and curse fee 
- Updated sarco summary page to show curse fee
- Currently the curse fee is hard coded in the `useLoadArchaeologists.ts` hook.

We should consider showing a total for sarco fees on the sarco summary page. 
![image](https://user-images.githubusercontent.com/34484576/229907443-547bb973-f69e-4431-ab4e-28cbf4fc07ca.png)

![image](https://user-images.githubusercontent.com/34484576/229907512-4b103092-f769-49fd-bd1a-87390489a63e.png)
![image](https://user-images.githubusercontent.com/34484576/229907580-4d19b8ee-3b81-449b-84ea-fdc677f62ac6.png)
![image](https://user-images.githubusercontent.com/34484576/229907613-12fb66b3-1a57-48d8-9681-33ff25a339ac.png)

