### PR TITLE
Remove curse fee tooltip if no resurrection set

### DIFF
--- a/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
@@ -24,7 +24,7 @@ interface TableContentProps {
   icon: boolean;
   checkbox: boolean;
   align?: string;
-  multiLineTooltipLabel?: string[];
+  multiLineTooltipLabel?: string[] | null;
 }
 
 export function ArchaeologistListItem({
@@ -75,7 +75,7 @@ export function ArchaeologistListItem({
         isNumeric
       >
         <MultiLineTooltip
-          lines={multiLineTooltipLabel}
+          lines={multiLineTooltipLabel ?? []}
           placement="top"
         >
           <Flex justify={align || (icon || checkbox ? 'left' : 'center')}>
@@ -137,10 +137,12 @@ export function ArchaeologistListItem({
         <TableContent
           icon={true}
           checkbox={false}
-          multiLineTooltipLabel={[
-            `Digging fee: ${formatSarco(diggingFees?.toString() ?? '0')}`,
-            `Curse fee: ${formatSarco(archaeologist.profile.curseFee.toString())}`,
-          ]}
+          multiLineTooltipLabel={
+            diggingFees && [
+              `Digging fee: ${formatSarco(diggingFees?.toString() ?? '0')}`,
+              `Curse fee: ${formatSarco(archaeologist.profile.curseFee.toString())}`,
+            ]
+          }
         >
           {diggingFees
             ? formatSarco(totalFees?.toString() ?? '0')


### PR DESCRIPTION
There is a tooltip that shows the digging fee and curse fee denominations when you hover over the digging fee on the arch list. If no resurrection is set, this value only shows sarco/month rate. Adding the curse fee to the sarco/month value makes no sense, so this PR simply hides the tooltip if sarco/month is being shown.

