### PR TITLE
Add curse fee column

### DIFF
--- a/src/components/RetryCreateModal.tsx
+++ b/src/components/RetryCreateModal.tsx
@@ -61,6 +61,8 @@ export function RetryCreateModal({
   return (
     <SarcoModal
       isDismissible={false}
+      showCancelButton={true}
+      onCancelClick={cancelCreation}
       secondaryButton={{
         dismissesModal: true,
         label: validationFailed ? 'Cancel Sarcophagus' : 'Continue',

--- a/src/components/useSarcoModal.tsx
+++ b/src/components/useSarcoModal.tsx
@@ -10,6 +10,7 @@ import {
   useDisclosure,
   Box,
   Flex,
+  HStack,
 } from '@chakra-ui/react';
 import { colors } from 'theme/colors';
 
@@ -22,6 +23,8 @@ interface ModalButtonProps {
 interface SarcoModalProps {
   children: JSX.Element[] | JSX.Element;
   isDismissible: boolean;
+  showCancelButton?: boolean;
+  onCancelClick?: Function;
   coverImage?: JSX.Element;
   title?: JSX.Element;
   secondaryButton?: ModalButtonProps;
@@ -77,17 +80,31 @@ export function useSarcoModal() {
         </ModalBody>
 
         <ModalFooter alignSelf={'center'}>
-          {props.secondaryButton && (
-            <Button
-              variant="ghost"
-              onClick={() => {
-                props.secondaryButton?.onClick();
-                if (props.secondaryButton?.dismissesModal) onClose();
-              }}
-            >
-              {props.secondaryButton.label}
-            </Button>
-          )}
+          <HStack>
+            {props.showCancelButton && (
+              <Button
+                variant="ghost"
+                color="#bbb"
+                onClick={() => {
+                  if (props.onCancelClick) props.onCancelClick();
+                  onClose();
+                }}
+              >
+                Cancel
+              </Button>
+            )}
+            {props.secondaryButton && (
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  props.secondaryButton?.onClick();
+                  if (props.secondaryButton?.dismissesModal) onClose();
+                }}
+              >
+                {props.secondaryButton.label}
+              </Button>
+            )}
+          </HStack>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistHeader.tsx
@@ -10,6 +10,7 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react';
 import { ethers } from 'ethers';
+import { useGetProtocolFeeBasePercentage } from 'hooks/viewStateFacet';
 import { calculateProjectedDiggingFees, formatSarco } from 'lib/utils/helpers';
 import { useMemo } from 'react';
 import { setShowSelectedArchaeologists } from 'store/archaeologistList/actions';
@@ -24,6 +25,7 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
   const { selectedArchaeologists, resurrection } = useSelector(x => x.embalmState);
   const { showOnlySelectedArchaeologists } = useSelector(x => x.archaeologistListState);
   const { timestampMs } = useSelector(x => x.appState);
+  const protocolFeeBasePercentage = useGetProtocolFeeBasePercentage();
 
   function toggleShowOnlySelected() {
     dispatch(setShowSelectedArchaeologists(!showOnlySelectedArchaeologists));
@@ -79,7 +81,7 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
         {resurrection ? (
           <HStack mr={2}>
             <Tooltip
-              label="This is how much SARCO it will cost you the next time you rewrap the Sarcophagus"
+              label="This is how much SARCO you will pay in total to your selected Archaeologists to create your Sarcophagus. (NOTE: This sum does not include protocol fees)"
               placement="top"
             >
               <Icon as={InfoOutlineIcon}></Icon>
@@ -97,9 +99,9 @@ export function ArchaeologistHeader({ resetPage }: ResetPage) {
             <Text
               variant="secondary"
               as="i"
-              fontSize="10"
+              fontSize="12"
             >
-              +1% protocol fee
+              + {protocolFeeBasePercentage / 100}% protocol fee
             </Text>
           </HStack>
         ) : (

--- a/src/features/embalm/stepContent/components/ArchaeologistList.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistList.tsx
@@ -40,11 +40,13 @@ export function ArchaeologistList({
     selectedArchaeologists,
     hiddenArchaeologists,
     onClickSortDiggingFees,
+    onClickSortCurseFee,
     onClickSortUnwraps,
     onClickSortFails,
     onClickSortArchs,
     archaeologistFilterSort,
     diggingFeesFilter,
+    curseFeeFilter,
     archAddressSearch,
     unwrapsFilter,
     failsFilter,
@@ -129,7 +131,7 @@ export function ArchaeologistList({
                             direction="column"
                             alignItems="flex-start"
                           >
-                            <Text> Fees </Text>
+                            <Text> Digging Fee </Text>
                             {resurrectionTime === 0 && (
                               <Text
                                 fontSize="xs"
@@ -154,6 +156,43 @@ export function ArchaeologistList({
                       <FilterInput
                         filterName={SortFilterType.DIGGING_FEES}
                         value={diggingFeesFilter}
+                        placeholder="max"
+                        color="brand.950"
+                      />
+                    </VStack>
+                  </Th>
+                  <Th
+                    isNumeric
+                    borderBottom="none"
+                  >
+                    <VStack align="left">
+                      <HStack>
+                        <Button
+                          variant="ghost"
+                          rightIcon={filterIcon(SortFilterType.CURSE_FEE)}
+                          onClick={onClickSortCurseFee}
+                          p={'0.5'}
+                        >
+                          <Flex
+                            direction="column"
+                            alignItems="flex-start"
+                          >
+                            <Text> Curse Fee </Text>
+                          </Flex>
+                        </Button>
+                        <Tooltip
+                          label="A one time fee to be paid for the Archaeologist to be cursed on this Sarcophagus"
+                          placement="top"
+                        >
+                          <Icon
+                            as={QuestionIcon}
+                            color="brand.950"
+                          />
+                        </Tooltip>
+                      </HStack>
+                      <FilterInput
+                        filterName={SortFilterType.CURSE_FEE}
+                        value={curseFeeFilter}
                         placeholder="max"
                         color="brand.950"
                       />

--- a/src/features/embalm/stepContent/components/ArchaeologistList.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistList.tsx
@@ -143,15 +143,17 @@ export function ArchaeologistList({
                             )}
                           </Flex>
                         </Button>
-                        <Tooltip
-                          label="Amount to be paid for the next rewrap"
-                          placement="top"
-                        >
-                          <Icon
-                            as={QuestionIcon}
-                            color="brand.950"
-                          />
-                        </Tooltip>
+                        {resurrectionTime === 0 ? null : (
+                          <Tooltip
+                            label="Amount to be paid to the archaeologist in order for it to resurrect at the resurrrection time you have selected."
+                            placement="top"
+                          >
+                            <Icon
+                              as={QuestionIcon}
+                              color="brand.950"
+                            />
+                          </Tooltip>
+                        )}
                       </HStack>
                       <FilterInput
                         filterName={SortFilterType.DIGGING_FEES}
@@ -181,7 +183,7 @@ export function ArchaeologistList({
                           </Flex>
                         </Button>
                         <Tooltip
-                          label="A one time fee to be paid for the Archaeologist to be cursed on this Sarcophagus"
+                          label="A one time fee to be paid to the Archaeologist in order to be cursed on your Sarcophagus."
                           placement="top"
                         >
                           <Icon

--- a/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
+++ b/src/features/embalm/stepContent/components/ArchaeologistListItem.tsx
@@ -18,6 +18,7 @@ import { useEnsName } from 'wagmi';
 import { useAttemptDialArchaeologists } from '../../../../hooks/utils/useAttemptDialArchaeologists';
 import { Archaeologist } from '../../../../types/index';
 import { MultiLineTooltip } from './MultiLineTooltip';
+import { BigNumber } from 'ethers';
 
 interface ArchaeologistListItemProps {
   archaeologist: Archaeologist;
@@ -52,9 +53,11 @@ export function ArchaeologistListItem({
   const resurrectionTime = useSelector(s => s.embalmState.resurrection);
   const { timestampMs } = useSelector(s => s.appState);
 
-  const diggingFees = calculateDiggingFees(archaeologist, resurrectionTime, timestampMs);
-
-  const totalFees = diggingFees?.add(archaeologist.profile.curseFee);
+  const diggingFees: BigNumber | null = calculateDiggingFees(
+    archaeologist,
+    resurrectionTime,
+    timestampMs
+  );
 
   const { data: ensName } = useEnsName({
     address: archaeologist.profile.archAddress as `0x${string}`,
@@ -145,27 +148,30 @@ export function ArchaeologistListItem({
         <TableContent
           icon={true}
           checkbox={false}
-          multiLineTooltipLabel={
-            diggingFees && [
-              `Digging fee: ${formatSarco(diggingFees?.toString() ?? '0')}`,
-              `Curse fee: ${formatSarco(archaeologist.profile.curseFee.toString())}`,
-            ]
-          }
         >
           {diggingFees
-            ? formatSarco(totalFees?.toString() ?? '0')
+            ? formatSarco(diggingFees?.toString() ?? '0')
             : formatSarco(
                 convertSarcoPerSecondToPerMonth(
                   archaeologist.profile.minimumDiggingFeePerSecond.toString()
                 )
               )}
         </TableContent>
+
+        <TableContent
+          icon={true}
+          checkbox={false}
+        >
+          {formatSarco(archaeologist.profile.curseFee.toString())}
+        </TableContent>
+
         <TableContent
           icon={false}
           checkbox={false}
         >
           {archaeologist.profile.successes.toString()}
         </TableContent>
+
         <TableContent
           icon={false}
           checkbox={false}

--- a/src/features/embalm/stepContent/components/FilterInput.tsx
+++ b/src/features/embalm/stepContent/components/FilterInput.tsx
@@ -15,6 +15,7 @@ import {
   SortFilterType,
   ArchaeologistListActions,
   setArchAddressSearch,
+  setCurseFeeFilter,
 } from 'store/archaeologistList/actions';
 import { SarcoTokenIcon } from 'components/icons';
 import { useDispatch } from 'store/index';
@@ -106,6 +107,17 @@ export function FilterInput({ filterName, placeholder = '', ...rest }: FilterPro
           filterWidth={'150px'}
           placeholder={placeholder}
           filterTypeAction={setDiggingFeesFilter}
+          icon={true}
+          {...rest}
+        />
+      );
+
+    case SortFilterType.CURSE_FEE:
+      return (
+        <NumberInputFilterComponent
+          filterWidth={'150px'}
+          placeholder={placeholder}
+          filterTypeAction={setCurseFeeFilter}
           icon={true}
           {...rest}
         />

--- a/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
+++ b/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
@@ -32,7 +32,7 @@ export function SarcophagusSummaryFees() {
         )
       : BigNumber.from(0);
 
-  const totalFees = diggingFeesAndCurseFees.add(protocolFee);
+  const totalFees = diggingFeesAndCurseFees.add(protocolFee).add(uploadPrice);
 
   return (
     <Box
@@ -48,7 +48,7 @@ export function SarcophagusSummaryFees() {
             <SummaryErrorIcon error={"You don't have enough SARCO to cover creation fees!"} />
           ) : (
             <Tooltip
-              label="Fee to be paid for the next rewrap, and a one time upload fee"
+              label="This is how much SARCO it will cost in total to create your Sarcophagus. (NOTE: This includes a one time upload fee)"
               placement="top"
             >
               <InfoOutlineIcon fontSize="md" />
@@ -102,8 +102,8 @@ export function SarcophagusSummaryFees() {
             w="100%"
             justifyContent="space-between"
           >
-            <Text as="i">Total Fees</Text>
-            <Text as="i">{formatSarco(totalFees.toString())} SARCO</Text>
+            <Text as="i">Payload Upload</Text>
+            <Text as="i">{formatFee(ethers.utils.formatUnits(uploadPrice), 4)} ETH</Text>
           </Flex>
           <Divider
             my={2}
@@ -113,8 +113,20 @@ export function SarcophagusSummaryFees() {
             w="100%"
             justifyContent="space-between"
           >
-            <Text as="i">Payload Upload</Text>
-            <Text as="i">{formatFee(ethers.utils.formatUnits(uploadPrice), 4)} ETH</Text>
+            <Text
+              as="i"
+              fontSize="16"
+              fontWeight="bold"
+            >
+              Total:
+            </Text>
+            <Text
+              as="i"
+              fontSize="16"
+              fontWeight="bold"
+            >
+              {formatSarco(totalFees.toString(), 8)} SARCO
+            </Text>
           </Flex>
         </Flex>
       </Flex>

--- a/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
+++ b/src/features/embalm/stepContent/hooks/useArchaeologistList.ts
@@ -20,6 +20,7 @@ export function useArchaeologistList() {
   const {
     archaeologistFilterSort,
     diggingFeesFilter,
+    curseFeeFilter,
     unwrapsFilter,
     failsFilter,
     archAddressSearch,
@@ -93,6 +94,10 @@ export function useArchaeologistList() {
     dispatch(setSortDirection(SortFilterType.DIGGING_FEES, directionValue));
   }
 
+  function onClickSortCurseFee() {
+    dispatch(setSortDirection(SortFilterType.CURSE_FEE, directionValue));
+  }
+
   function onClickSortUnwraps() {
     dispatch(setSortDirection(SortFilterType.UNWRAPS, directionValue));
   }
@@ -161,6 +166,9 @@ export function useArchaeologistList() {
           .lte(
             (diggingFeesFilter && ethers.utils.parseEther(diggingFeesFilter)) || constants.MaxInt256
           ) &&
+        arch.profile.curseFee.lte(
+          (curseFeeFilter && ethers.utils.parseEther(curseFeeFilter)) || constants.MaxInt256
+        ) &&
         arch.profile.successes.gte(unwrapsFilter || constants.MinInt256) &&
         arch.profile.failures.lte(failsFilter || constants.MaxInt256)
     );
@@ -174,11 +182,13 @@ export function useArchaeologistList() {
     archAddressSearch,
     archaeologistFilterSort,
     diggingFeesFilter,
+    curseFeeFilter,
     failsFilter,
     handleCheckArchaeologist,
     hiddenArchaeologists,
     onClickSortArchs,
     onClickSortDiggingFees,
+    onClickSortCurseFee,
     onClickSortFails,
     onClickSortUnwraps,
     selectedArchaeologists,

--- a/src/hooks/useSubgraph.ts
+++ b/src/hooks/useSubgraph.ts
@@ -67,22 +67,25 @@ export function useGraphQl() {
     }
   }, [graphQlClient]);
 
-  const getSarcophagusRewraps = useCallback(async (sarcoId: string) => {
-    try {
-      const { rewrapSarcophaguses } = (
-        await graphQlClient.query({
-          query: gql(getSarcoRewrapsQuery(sarcoId)),
-          fetchPolicy: 'cache-first',
-        })
-      ).data as { rewrapSarcophaguses: any[] };
+  const getSarcophagusRewraps = useCallback(
+    async (sarcoId: string) => {
+      try {
+        const { rewrapSarcophaguses } = (
+          await graphQlClient.query({
+            query: gql(getSarcoRewrapsQuery(sarcoId)),
+            fetchPolicy: 'cache-first',
+          })
+        ).data as { rewrapSarcophaguses: any[] };
 
-      return rewrapSarcophaguses;
-    } catch (e) {
-      console.error(e);
-      Sentry.captureException(e, { fingerprint: ['SUBGRAPH_EXCEPTION'] });
-      return [];
-    }
-  }, [graphQlClient]);
+        return rewrapSarcophaguses;
+      } catch (e) {
+        console.error(e);
+        Sentry.captureException(e, { fingerprint: ['SUBGRAPH_EXCEPTION'] });
+        return [];
+      }
+    },
+    [graphQlClient]
+  );
 
   return { getArchaeologists, getSarcophagusRewraps };
 }

--- a/src/store/archaeologistList/actions.ts
+++ b/src/store/archaeologistList/actions.ts
@@ -7,6 +7,7 @@ export enum ActionType {
   SetShowSelectedArchaeologists = 'EMBALM_SET_SHOW_SELECTED_ARCHAEOLOGISTS',
   ToggleShowHiddenArchaeologists = 'EMBALM_TOGGLE_SHOW_HIDDEN_ARCHAEOLOGISTS',
   SetDiggingFeesFilter = 'EMBALM_SET_DIGGING_FEES_FILTER',
+  SetCurseFeeFilter = 'EMBALM_SET_CURSE_FEE_FILTER',
   SetUnwrapsFilter = 'EMBALM_SET_UNWRAPS_FILTER',
   SetFailsFilter = 'EMBALM_SET_FAILS_FILTER',
   SetArchAddressSearch = 'EMBALM_SET_ARCH_ADDRESS_SEARCH',
@@ -21,6 +22,7 @@ export enum SortDirection {
 export enum SortFilterType {
   ADDRESS_SEARCH,
   DIGGING_FEES,
+  CURSE_FEE,
   UNWRAPS,
   FAILS,
   NONE,
@@ -29,6 +31,7 @@ export enum SortFilterType {
 type ArchaeologistListPayload = {
   [ActionType.SetSortDirection]: { direction: SortDirection; sortType: SortFilterType };
   [ActionType.SetDiggingFeesFilter]: { filter: string };
+  [ActionType.SetCurseFeeFilter]: { filter: string };
   [ActionType.SetUnwrapsFilter]: { filter: string };
   [ActionType.SetFailsFilter]: { filter: string };
   [ActionType.SetArchAddressSearch]: { search: string };
@@ -52,6 +55,15 @@ export function setSortDirection(
 export function setDiggingFeesFilter(filter: string): ArchaeologistListActions {
   return {
     type: ActionType.SetDiggingFeesFilter,
+    payload: {
+      filter,
+    },
+  };
+}
+
+export function setCurseFeeFilter(filter: string): ArchaeologistListActions {
+  return {
+    type: ActionType.SetCurseFeeFilter,
     payload: {
       filter,
     },

--- a/src/store/archaeologistList/reducer.ts
+++ b/src/store/archaeologistList/reducer.ts
@@ -4,6 +4,7 @@ import { ActionType, SortDirection, SortFilterType } from './actions';
 export interface ArchaeologistListState {
   archaeologistFilterSort: { sortDirection: SortDirection; sortType: SortFilterType };
   diggingFeesFilter: string;
+  curseFeeFilter: string;
   unwrapsFilter: string;
   failsFilter: string;
   archAddressSearch: string;
@@ -14,6 +15,7 @@ export interface ArchaeologistListState {
 export const archaeologistListInitialState: ArchaeologistListState = {
   archaeologistFilterSort: { sortDirection: SortDirection.NONE, sortType: SortFilterType.NONE },
   diggingFeesFilter: '',
+  curseFeeFilter: '',
   unwrapsFilter: '',
   failsFilter: '',
   archAddressSearch: '',
@@ -37,6 +39,9 @@ export function archaeologistListReducer(
 
     case ActionType.SetDiggingFeesFilter:
       return { ...state, diggingFeesFilter: action.payload.filter };
+
+    case ActionType.SetCurseFeeFilter:
+      return { ...state, curseFeeFilter: action.payload.filter };
 
     case ActionType.SetUnwrapsFilter:
       return { ...state, unwrapsFilter: action.payload.filter };


### PR DESCRIPTION
This PR separates the "fees" column in the arch list to digging fees and curse fee columns.

I have also updated some tooltips messages, and slightly rearranged the fees summary UI.

Also added a cancel button to the retry sarco modal, as currently implementation forced user to continue to retry even if they might not want to.

I also updated the total fees calculation in the summary view to include the upload price