### PR TITLE
Show wallet not connected page if there is no wallet

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -212,9 +212,7 @@ export function Pages() {
           height="100%"
           pt={50}
         >
-          {!isSarcoInitialized ? (
-            <Flex></Flex>
-          ) : isConnected && isSupportedChain ? (
+          {isSarcoInitialized && isConnected && isSupportedChain ? (
             <Routes>
               <Route
                 path="/"


### PR DESCRIPTION
Shows the wallet disconnected page if the user has no wallet. 

Open an incognito browser and open the app. Before, a blank screen was shown. Now the "No wallet connected" page will show instead. 

![image](https://github.com/sarcophagus-org/sarcophagus-v2-app/assets/34484576/ced18396-1b66-40ea-860d-cc5efa74b7b0)
