### PR TITLE
Make the sarco summary message more relevant

### DIFF
--- a/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
+++ b/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
@@ -15,8 +15,7 @@ export function ReviewSarcophagus() {
     >
       <Text>
         Review your details below. Once you are ready, you can submit your transactions. Be aware,
-        you will also make two transactions: (1) encrypt your payload, and (2) upload your payload
-        to Arweave via Bundlr.
+        you will make multiple transactions.
       </Text>
 
       <Flex


### PR DESCRIPTION
Makes the sarco summary message more relevant. More thought could go into this but at least now it is correct.

### Before
![image](https://github.com/sarcophagus-org/sarcophagus-v2-app/assets/34484576/d0691d96-d9b2-47fe-a9f2-77e0d410ea4f)

### After
![image](https://github.com/sarcophagus-org/sarcophagus-v2-app/assets/34484576/2b427f75-901f-4805-9986-c6b8965a3498)
