### PR TITLE
Fix network change inconsistencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@libp2p/webrtc-star": "^5.0.3",
         "@libp2p/websockets": "^5.0.1",
         "@multiformats/multiaddr": "^10.0.3",
-        "@rainbow-me/rainbowkit": "0.8.1",
+        "@rainbow-me/rainbowkit": "^0.12.18",
         "@react-pdf/renderer": "^3.0.0",
         "@sarcophagus-org/sarcophagus-v2-contracts": "^0.17.2",
         "@sarcophagus-org/sarcophagus-v2-sdk-client": "^0.2.8",
@@ -74,9 +74,9 @@
         "shamirs-secret-sharing-ts": "^1.0.2",
         "stream-browserify": "^3.0.0",
         "stream-http": "^3.2.0",
-        "typescript": "^4.7.3",
+        "typescript": "^4.9.4",
         "url": "^0.11.0",
-        "wagmi": "^0.9.5",
+        "wagmi": "^0.12.19",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -3810,9 +3810,9 @@
       }
     },
     "node_modules/@coinbase/wallet-sdk": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.6.3.tgz",
-      "integrity": "sha512-XUR4poOJE+dKzwBTdlM693CdLFitr046oZOVY3iDnbFcRrrQswhbDji7q4CmUcD4HxbfViX7PFoIwl79YQcukg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.7.1.tgz",
+      "integrity": "sha512-LjyoDCB+7p0waQXfK+fUgcAs3Ezk6S6e+LYaoFjpJ6c9VTop3NyZF40Pi7df4z7QJohCwzuIDjz0Rhtig6Y7Pg==",
       "dependencies": {
         "@metamask/safe-event-emitter": "2.0.0",
         "@solana/web3.js": "^1.70.1",
@@ -3820,8 +3820,8 @@
         "bn.js": "^5.1.1",
         "buffer": "^6.0.3",
         "clsx": "^1.1.0",
-        "eth-block-tracker": "4.4.3",
-        "eth-json-rpc-filters": "4.2.2",
+        "eth-block-tracker": "6.1.0",
+        "eth-json-rpc-filters": "5.1.0",
         "eth-rpc-errors": "4.0.2",
         "json-rpc-engine": "6.1.0",
         "keccak": "^3.0.1",
@@ -3840,6 +3840,46 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/eth-block-tracker": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-6.1.0.tgz",
+      "integrity": "sha512-K9SY8+/xMBi4M5HHTDdxnpEqEEGjbNpzHFqvxyjMZej8InV/B+CkFRKM6W+uvrFJ7m8Zd1E0qUkseU3vdIDFYQ==",
+      "dependencies": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "@metamask/utils": "^3.0.1",
+        "json-rpc-random-id": "^1.0.1",
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/eth-json-rpc-filters": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-5.1.0.tgz",
+      "integrity": "sha512-fos+9xmoa1A2Ytsc9eYof17r81BjdJOUcGcgZn4K/tKdCCTb+a8ytEtwlu1op5qsXFDlgGmstTELFrDEc89qEQ==",
+      "dependencies": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "async-mutex": "^0.2.6",
+        "eth-query": "^2.1.2",
+        "json-rpc-engine": "^6.1.0",
+        "pify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/eth-json-rpc-filters/node_modules/pify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/eth-rpc-errors": {
       "version": "4.0.2",
@@ -5455,49 +5495,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@json-rpc-tools/provider": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@json-rpc-tools/utils": "^1.7.6",
-        "axios": "^0.21.0",
-        "safe-json-utils": "^1.1.1",
-        "ws": "^7.4.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/provider/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "node_modules/@ledgerhq/connect-kit-loader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.0.2.tgz",
-      "integrity": "sha512-TQ21IjcZOw/scqypaVFY3jHVqI7X7Hta3qN/us6FvTol3AY06UmrhhXGww0E9xHmAbdX241ddwXEiMBSQZFr9g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.2.tgz",
+      "integrity": "sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A=="
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -7333,19 +7334,69 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
+      "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
     "node_modules/@metamask/safe-event-emitter": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
       "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==",
       "license": "ISC"
     },
-    "node_modules/@motionone/animation": {
-      "version": "10.13.2",
-      "license": "MIT",
+    "node_modules/@metamask/utils": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-3.6.0.tgz",
+      "integrity": "sha512-9cIRrfkWvHblSiNDVXsjivqa9Ak0RYo/1H6tqTqTbAx+oBK2Sva0lWDHxGchOqA7bySGUJKAWSNJvH6gdHZ0gQ==",
       "dependencies": {
-        "@motionone/easing": "^10.13.2",
-        "@motionone/types": "^10.13.2",
-        "@motionone/utils": "^10.13.2",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "semver": "^7.3.8",
+        "superstruct": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@metamask/utils/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@metamask/utils/node_modules/superstruct": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
+      "integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@motionone/animation": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
+      "integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
+      "dependencies": {
+        "@motionone/easing": "^10.15.1",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
         "tslib": "^2.3.1"
       }
     },
@@ -7364,31 +7415,79 @@
       }
     },
     "node_modules/@motionone/easing": {
-      "version": "10.13.2",
-      "license": "MIT",
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
+      "integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
       "dependencies": {
-        "@motionone/utils": "^10.13.2",
+        "@motionone/utils": "^10.15.1",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@motionone/generators": {
-      "version": "10.13.2",
-      "license": "MIT",
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
+      "integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
       "dependencies": {
-        "@motionone/types": "^10.13.2",
-        "@motionone/utils": "^10.13.2",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/svelte": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.2.tgz",
+      "integrity": "sha512-38xsroKrfK+aHYhuQlE6eFcGy0EwrB43Q7RGjF73j/kRUTcLNu/LAaKiLLsN5lyqVzCgTBVt4TMT/ShWbTbc5Q==",
+      "dependencies": {
+        "@motionone/dom": "^10.16.2",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/svelte/node_modules/@motionone/dom": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.16.2.tgz",
+      "integrity": "sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==",
+      "dependencies": {
+        "@motionone/animation": "^10.15.1",
+        "@motionone/generators": "^10.15.1",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "hey-listen": "^1.0.8",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@motionone/types": {
-      "version": "10.13.2",
-      "license": "MIT"
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
+      "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
     },
     "node_modules/@motionone/utils": {
-      "version": "10.13.2",
-      "license": "MIT",
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
+      "integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
       "dependencies": {
-        "@motionone/types": "^10.13.2",
+        "@motionone/types": "^10.15.1",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/vue": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.2.tgz",
+      "integrity": "sha512-7/dEK/nWQXOkJ70bqb2KyNfSWbNvWqKKq1C8juj+0Mg/AorgD8O5wE3naddK0G+aXuNMqRuc4jlsYHHWHtIzVw==",
+      "dependencies": {
+        "@motionone/dom": "^10.16.2",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/vue/node_modules/@motionone/dom": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.16.2.tgz",
+      "integrity": "sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==",
+      "dependencies": {
+        "@motionone/animation": "^10.15.1",
+        "@motionone/generators": "^10.15.1",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
         "hey-listen": "^1.0.8",
         "tslib": "^2.3.1"
       }
@@ -7818,11 +7917,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
-    },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.7",
       "license": "MIT",
@@ -8055,9 +8149,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@rainbow-me/rainbowkit": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-0.8.1.tgz",
-      "integrity": "sha512-A8BjihvgCY/xjQWOpqgOce+uO4mmIV4Qlo3XMF87kk5WNmyLLaPx2oYTJQz1uOinWE77h4G0HozJr5wnrermgw==",
+      "version": "0.12.18",
+      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-0.12.18.tgz",
+      "integrity": "sha512-Ehpr8gBCS8v4vdXLi8ZBlQ1yA6GHJOhoP66hLrdgI5iSlr6aUGTEicEfb2RaKNltHJFW/5A4BKst0AK4PkAkuw==",
       "dependencies": {
         "@vanilla-extract/css": "1.9.1",
         "@vanilla-extract/dynamic": "2.0.2",
@@ -8070,10 +8164,10 @@
         "node": ">=12.4"
       },
       "peerDependencies": {
-        "ethers": ">=5.5.1",
+        "ethers": ">=5.6.8",
         "react": ">=17",
         "react-dom": ">=17",
-        "wagmi": "0.9.x"
+        "wagmi": ">=0.12.19 <1.0.0"
       }
     },
     "node_modules/@rainbow-me/rainbowkit/node_modules/qrcode": {
@@ -8356,6 +8450,41 @@
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.1.4",
       "license": "MIT"
+    },
+    "node_modules/@safe-global/safe-apps-provider": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.15.2.tgz",
+      "integrity": "sha512-BaoGAuY7h6jLBL7P+M6b7hd+1QfTv8uMyNF3udhiNUwA0XwfzH2ePQB13IEV3Mn7wdcIMEEUDS5kHbtAsj60qQ==",
+      "dependencies": {
+        "@safe-global/safe-apps-sdk": "7.9.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@safe-global/safe-apps-provider/node_modules/@safe-global/safe-apps-sdk": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-7.9.0.tgz",
+      "integrity": "sha512-S2EI+JL8ocSgE3uGNaDZCzKmwfhtxXZFDUP76vN0FeaY35itFMyi8F0Vhxu0XnZm3yLzJE3tp5px6GhuQFLU6w==",
+      "dependencies": {
+        "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
+        "ethers": "^5.7.2"
+      }
+    },
+    "node_modules/@safe-global/safe-apps-sdk": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-7.11.0.tgz",
+      "integrity": "sha512-RDamzPM1Lhhiiz0O+Dn6FkFqIh47jmZX+HCV/BBnBBOSKfBJE//IGD3+02zMgojXHTikQAburdPes9qmH1SA1A==",
+      "dependencies": {
+        "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
+        "ethers": "^5.7.2"
+      }
+    },
+    "node_modules/@safe-global/safe-gateway-typescript-sdk": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.10.0.tgz",
+      "integrity": "sha512-nhWjFRRgrGz4uZbyQ3Hgm4si1AixCWlnvi5WUCq/+V+e8EoA2Apj9xJEt8zzXvtELlddFqkH2sfTFy9LIjGXKg==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      }
     },
     "node_modules/@sarcophagus-org/sarcophagus-v2-contracts": {
       "version": "0.17.2",
@@ -8976,6 +9105,41 @@
       "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==",
       "license": "MIT"
     },
+    "node_modules/@stablelib/ed25519": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
+      "integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
+      "dependencies": {
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha512": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/hash": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
+      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
+    },
+    "node_modules/@stablelib/hkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
+      "integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
+      "dependencies": {
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/hmac": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/hmac": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
+      "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
+      "dependencies": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
     "node_modules/@stablelib/int": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
@@ -9006,6 +9170,26 @@
       "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/sha256": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
+      "integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/sha512": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
+      "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
@@ -9298,32 +9482,32 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.20.4.tgz",
-      "integrity": "sha512-lhLtGVNJDsJ/DyZXrLzekDEywQqRVykgBqTmkv0La32a/RleILXy6JMLBb7UmS3QCatg/F/0N9/5b0i5j6IKcA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.33.0.tgz",
+      "integrity": "sha512-qYu73ptvnzRh6se2nyBIDHGBQvPY1XXl3yR769B7B6mIDD7s+EZhdlWHQ67JI6UOTFRaI7wupnTnwJ3gE0Mr/g==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/query-persist-client-core": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-4.20.4.tgz",
-      "integrity": "sha512-MzrRC9esSEpD/kY28Zi4YqkWvuOUmpO67vpgCkQszOLbAHLMeEibId3njXxIZXDPg5fvX3HaAwFS7GheuMuKFg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-4.33.0.tgz",
+      "integrity": "sha512-3P16+2JjcUU5CHi10jJuwd0ZQYvQtSuzLvCUCjVuAnj3GZjfSso1v8t6WAObAr9RPuIC6vDXeOQ3mr07EF/NxQ==",
+      "dependencies": {
+        "@tanstack/query-core": "4.33.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/query-core": "4.20.4"
       }
     },
     "node_modules/@tanstack/query-sync-storage-persister": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-4.20.4.tgz",
-      "integrity": "sha512-+LrpqZDScy9FfyJJGSY6/sMbgi9zHbDCXWOwpKJ2aPfTblk0cAJDjlM7rS49FXZD//edEJehm9SgRhFN2/9pSg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-4.33.0.tgz",
+      "integrity": "sha512-V6igMcdEOXPRpvmNFQ6I/iJaw9NhxWy7x8PWamm2cgSsLi8bHaDvUVuWkZm+ikI47QjoCUk7qll/82JYLaH+pw==",
       "dependencies": {
-        "@tanstack/query-persist-client-core": "4.20.4"
+        "@tanstack/query-persist-client-core": "4.33.0"
       },
       "funding": {
         "type": "github",
@@ -9331,11 +9515,11 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.20.4.tgz",
-      "integrity": "sha512-SJRxx13k/csb9lXAJfycgVA1N/yU/h3bvRNWP0+aHMfMjmbyX82FdoAcckDBbOdEyAupvb0byelNHNeypCFSyA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.33.0.tgz",
+      "integrity": "sha512-97nGbmDK0/m0B86BdiXzx3EW9RcDYKpnyL2+WwyuLHEgpfThYAnXFaMMmnTDuAO4bQJXEhflumIEUfKmP7ESGA==",
       "dependencies": {
-        "@tanstack/query-core": "4.20.4",
+        "@tanstack/query-core": "4.33.0",
         "use-sync-external-store": "^1.2.0"
       },
       "funding": {
@@ -9357,18 +9541,18 @@
       }
     },
     "node_modules/@tanstack/react-query-persist-client": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-4.20.4.tgz",
-      "integrity": "sha512-fJvYdULQEa+PV7M3WzWNPWiP/VmWflyiISwIzu2/wC6TnsH7CzXwUwy5PvTl89AR26GR0/U5J6f+oS6JhLVJxQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-4.33.0.tgz",
+      "integrity": "sha512-B3q0r1tqTTSkd9vctyqFj28xdGZJ+Dnr/7H05Ta1JF1w7EauVQl8ILrmXADecwvILnr1xoZO6lvi2W+mZxMinw==",
       "dependencies": {
-        "@tanstack/query-persist-client-core": "4.20.4"
+        "@tanstack/query-persist-client-core": "4.33.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "4.20.4"
+        "@tanstack/react-query": "^4.33.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -9484,6 +9668,14 @@
       "dependencies": {
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "dependencies": {
+        "@types/ms": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -9648,6 +9840,11 @@
       "dependencies": {
         "moment": "*"
       }
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
       "version": "16.11.49",
@@ -10150,13 +10347,13 @@
       ]
     },
     "node_modules/@wagmi/connectors": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-0.1.2.tgz",
-      "integrity": "sha512-YfhZMQMqBl69xbhs5rokGjAVfKN9Ynlsw4SgU/BGuxKpHY9VRWUGAEhgpHRTVcs72qBick3HNQv4wuFqx0Z1CQ==",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-0.3.24.tgz",
+      "integrity": "sha512-1pI0G9HRblc651dCz9LXuEu/zWQk23XwOUYqJEINb/c2TTLtw5TnTRIcefxxK6RnxeJvcKfnmK0rdZp/4ujFAA==",
       "funding": [
         {
           "type": "gitcoin",
-          "url": "https://gitcoin.co/grants/4493/wagmi-react-hooks-library-for-ethereum"
+          "url": "https://wagmi.sh/gitcoin"
         },
         {
           "type": "github",
@@ -10164,26 +10361,34 @@
         }
       ],
       "dependencies": {
-        "@coinbase/wallet-sdk": "^3.5.4",
+        "@coinbase/wallet-sdk": "^3.6.6",
         "@ledgerhq/connect-kit-loader": "^1.0.1",
-        "@walletconnect/ethereum-provider": "^1.8.0",
-        "abitype": "^0.1.8",
+        "@safe-global/safe-apps-provider": "^0.15.2",
+        "@safe-global/safe-apps-sdk": "^7.9.0",
+        "@walletconnect/ethereum-provider": "2.9.0",
+        "@walletconnect/legacy-provider": "^2.0.0",
+        "@walletconnect/modal": "^2.5.9",
+        "abitype": "^0.3.0",
         "eventemitter3": "^4.0.7"
       },
       "peerDependencies": {
-        "@wagmi/core": "0.8.x",
-        "ethers": "^5.0.0"
+        "@wagmi/core": ">=0.9.x",
+        "ethers": ">=5.5.1 <6",
+        "typescript": ">=4.9.4"
       },
       "peerDependenciesMeta": {
         "@wagmi/core": {
+          "optional": true
+        },
+        "typescript": {
           "optional": true
         }
       }
     },
     "node_modules/@wagmi/connectors/node_modules/abitype": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.1.8.tgz",
-      "integrity": "sha512-2pde0KepTzdfu19ZrzYTYVIWo69+6UbBCY4B1RDiwWgo2XZtFSJhF6C+XThuRXbbZ823J0Rw1Y5cP0NXYVcCdQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.3.0.tgz",
+      "integrity": "sha512-0YokyAV4hKMcy97Pl+6QgZBlBdZJN2llslOs7kiFY+cu7kMlVXDBpxMExfv0krzBCQt2t7hNovpQ3y/zvEm18A==",
       "funding": [
         {
           "type": "github",
@@ -10194,17 +10399,23 @@
         "pnpm": ">=7"
       },
       "peerDependencies": {
-        "typescript": ">=4.7.4"
+        "typescript": ">=4.9.4",
+        "zod": ">=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wagmi/core": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.8.5.tgz",
-      "integrity": "sha512-+oUQvJTs81QeD/vXqrhCSNVIiQy27yeHFiCWeDrvYZNyagp+8JO3wDom0pEd4UqEqhzHvFzAcHTmPWEq88B5uA==",
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.10.17.tgz",
+      "integrity": "sha512-qud45y3IlHp7gYWzoFeyysmhyokRie59Xa5tcx5F1E/v4moD5BY0kzD26mZW/ZQ3WZuVK/lZwiiPRqpqWH52Gw==",
       "funding": [
         {
           "type": "gitcoin",
-          "url": "https://gitcoin.co/grants/4493/wagmi-react-hooks-library-for-ethereum"
+          "url": "https://wagmi.sh/gitcoin"
         },
         {
           "type": "github",
@@ -10212,62 +10423,97 @@
         }
       ],
       "dependencies": {
-        "@wagmi/chains": "0.1.5",
-        "@wagmi/connectors": "0.1.2",
-        "abitype": "^0.2.5",
+        "@wagmi/chains": "0.2.22",
+        "@wagmi/connectors": "0.3.24",
+        "abitype": "^0.3.0",
         "eventemitter3": "^4.0.7",
-        "zustand": "^4.1.4"
+        "zustand": "^4.3.1"
       },
       "peerDependencies": {
-        "@coinbase/wallet-sdk": ">=3.6.0",
-        "@walletconnect/ethereum-provider": ">=1.7.5",
-        "ethers": ">=5.5.1"
+        "ethers": ">=5.5.1 <6",
+        "typescript": ">=4.9.4"
       },
       "peerDependenciesMeta": {
-        "@coinbase/wallet-sdk": {
-          "optional": true
-        },
-        "@walletconnect/ethereum-provider": {
+        "typescript": {
           "optional": true
         }
       }
     },
-    "node_modules/@walletconnect/browser-utils": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz",
-      "integrity": "sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==",
-      "dependencies": {
-        "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/window-getters": "1.0.0",
-        "@walletconnect/window-metadata": "1.0.0",
-        "detect-browser": "5.2.0"
+    "node_modules/@wagmi/core/node_modules/@wagmi/chains": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@wagmi/chains/-/chains-0.2.22.tgz",
+      "integrity": "sha512-TdiOzJT6TO1JrztRNjTA5Quz+UmQlbvWFG8N41u9tta0boHA1JCAzGGvU6KuIcOmJfRJkKOUIt67wlbopCpVHg==",
+      "funding": [
+        {
+          "type": "gitcoin",
+          "url": "https://wagmi.sh/gitcoin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "peerDependencies": {
+        "typescript": ">=4.9.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@walletconnect/browser-utils/node_modules/@walletconnect/safe-json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.0.tgz",
-      "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
-    },
-    "node_modules/@walletconnect/client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.8.0.tgz",
-      "integrity": "sha512-svyBQ14NHx6Cs2j4TpkQaBI/2AF4+LXz64FojTjMtV4VMMhl81jSO1vNeg+yYhQzvjcGH/GpSwixjyCW0xFBOQ==",
-      "dependencies": {
-        "@walletconnect/core": "^1.8.0",
-        "@walletconnect/iso-crypto": "^1.8.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0"
+    "node_modules/@wagmi/core/node_modules/abitype": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.3.0.tgz",
+      "integrity": "sha512-0YokyAV4hKMcy97Pl+6QgZBlBdZJN2llslOs7kiFY+cu7kMlVXDBpxMExfv0krzBCQt2t7hNovpQ3y/zvEm18A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "engines": {
+        "pnpm": ">=7"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.4",
+        "zod": ">=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-aFTHvEEbXcZ8XdWBw6rpQDte41Rxwnuk3SgTD8/iKGSRTni50gI9S3YEzMj05jozSiOBxQci4pJDMVhIUMtarw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-MZYJghS9YCvGe32UOgDj0mCasaOoGHQaYXWeQblXE/xb8HuaM6kAWhjIQN9P+MNp5QP134BHP5olQostcCotXQ==",
       "dependencies": {
-        "@walletconnect/socket-transport": "^1.8.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0"
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.12",
+        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/relay-auth": "^1.0.4",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
+        "events": "^3.3.0",
+        "lodash.isequal": "4.5.0",
+        "uint8arrays": "^3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/@walletconnect/crypto": {
@@ -10322,36 +10568,64 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/ethereum-provider": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-1.8.0.tgz",
-      "integrity": "sha512-Nq9m+oo5P0F+njsROHw9KMWdoc/8iGHYzQdkjJN/1C7DtsqFRg5k5a3hd9rzCLpbPsOC1q8Z5lRs6JQgDvPm6Q==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.9.0.tgz",
+      "integrity": "sha512-rSXkC0SXMigJRdIi/M2RMuEuATY1AwtlTWQBnqyxoht7xbO2bQNPCXn0XL4s/GRNrSUtoKSY4aPMHXV4W4yLBA==",
       "dependencies": {
-        "@walletconnect/client": "^1.8.0",
-        "@walletconnect/jsonrpc-http-connection": "^1.0.2",
-        "@walletconnect/jsonrpc-provider": "^1.0.5",
-        "@walletconnect/signer-connection": "^1.8.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0",
-        "eip1193-provider": "1.0.1",
-        "eventemitter3": "4.0.7"
+        "@walletconnect/jsonrpc-http-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "^1.0.13",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/sign-client": "2.9.0",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/universal-provider": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
+        "events": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@walletconnect/modal": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "@walletconnect/modal": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@walletconnect/iso-crypto": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.8.0.tgz",
-      "integrity": "sha512-pWy19KCyitpfXb70hA73r9FcvklS+FvO9QUIttp3c2mfW8frxgYeRXfxLRCIQTkaYueRKvdqPjbyhPLam508XQ==",
+    "node_modules/@walletconnect/events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
       "dependencies": {
-        "@walletconnect/crypto": "^1.0.2",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0"
+        "keyvaluestorage-interface": "^1.0.0",
+        "tslib": "1.14.1"
       }
+    },
+    "node_modules/@walletconnect/events/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/heartbeat": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
+      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/heartbeat/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-http-connection": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.4.tgz",
-      "integrity": "sha512-ji79pspdBhmIbTwve383tMaDu5Le9plW+oj5GE2aqzxIl3ib8JvRBZRn5lGEBGqVCvqB3MBJL7gBlEwpyRtoxQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.7.tgz",
+      "integrity": "sha512-qlfh8fCfu8LOM9JRR9KE0s0wxP6ZG9/Jom8M0qsoIQeKF3Ni0FyV4V1qy/cc7nfI46SLQLSl4tgWSfLiE1swyQ==",
       "dependencies": {
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
         "cross-fetch": "^3.1.4",
         "tslib": "1.14.1"
@@ -10363,12 +10637,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-provider": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.6.tgz",
-      "integrity": "sha512-f5vQxr53vUVQ51/9mRLb1OiNciT/546XZ68Byn9OYnDBGeGJXK2kQWDHp8sPWZbN5x0p7B6asdCWMVFJ6danlw==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
+      "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
       "dependencies": {
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/safe-json": "^1.0.2",
         "tslib": "1.14.1"
       }
     },
@@ -10378,9 +10652,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.2.tgz",
-      "integrity": "sha512-CZe8tjJX73OWdHjrBHy7HtAapJ2tT0Q3TYhPBhRxi3643lwPIQWC9En45ldY14TZwgSewkbZ0FtGBZK0G7Bbyg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -10392,12 +10666,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-utils": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.4.tgz",
-      "integrity": "sha512-y0+tDxcTZ9BHBBKBJbjZxLUXb+zQZCylf7y/jTvDPNx76J0hYYc+F9zHzyqBLeorSKepLTk6yI8hw3NXbAQB3g==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
       "dependencies": {
         "@walletconnect/environment": "^1.0.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
         "tslib": "1.14.1"
       }
     },
@@ -10406,240 +10680,154 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@walletconnect/mobile-registry": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/mobile-registry/-/mobile-registry-1.4.0.tgz",
-      "integrity": "sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw==",
-      "deprecated": "Deprecated in favor of dynamic registry available from: https://github.com/walletconnect/walletconnect-registry"
-    },
-    "node_modules/@walletconnect/qrcode-modal": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.8.0.tgz",
-      "integrity": "sha512-BueaFefaAi8mawE45eUtztg3ZFbsAH4DDXh1UNwdUlsvFMjqcYzLUG0xZvDd6z2eOpbgDg2N3bl6gF0KONj1dg==",
+    "node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
+      "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.8.0",
-        "@walletconnect/mobile-registry": "^1.4.0",
-        "@walletconnect/types": "^1.8.0",
-        "copy-to-clipboard": "^3.3.1",
-        "preact": "10.4.1",
-        "qrcode": "1.4.4"
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "tslib": "1.14.1",
+        "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "engines": {
-        "node": ">=6"
-      }
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+    "node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.0.2.tgz",
+      "integrity": "sha512-U/nNG+VLWoPFdwwKx0oliT4ziKQCEoQ27L5Hhw8YOFGA2Po9A9pULUYNWhDgHkrb0gYDNt//X7wABcEWWBd3FQ==",
       "dependencies": {
-        "color-convert": "^1.9.0"
+        "safe-json-utils": "^1.1.1",
+        "tslib": "1.14.1"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x",
+        "lokijs": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
         },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
+        "lokijs": {
+          "optional": true
         }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
+    "node_modules/@walletconnect/keyvaluestorage/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-    },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/is-fullwidth-code-point": {
+    "node_modules/@walletconnect/legacy-client": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-    },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-client/-/legacy-client-2.0.0.tgz",
+      "integrity": "sha512-v5L7rYk9loVnfvUf0mF+76bUPFaU5/Vh7mzL6/950CD/yoGdzYZ3Kj+L7mkC6HPMEGeQsBP1+sqBuiVGZ/aODA==",
       "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "@walletconnect/crypto": "^1.0.3",
+        "@walletconnect/encoding": "^1.0.2",
+        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/legacy-types": "^2.0.0",
+        "@walletconnect/legacy-utils": "^2.0.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "^5.3.0",
+        "query-string": "^6.13.5"
       }
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+    "node_modules/@walletconnect/legacy-modal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-modal/-/legacy-modal-2.0.0.tgz",
+      "integrity": "sha512-jckNd8lMhm4X7dX9TDdxM3bXKJnaqkRs6K2Mo5j6GmbIF9Eyx40jZ5+q457RVxvM6ciZEDT5s1wBHWdWoOo+9Q==",
       "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "@walletconnect/legacy-types": "^2.0.0",
+        "@walletconnect/legacy-utils": "^2.0.0",
+        "copy-to-clipboard": "^3.3.3",
+        "preact": "^10.12.0",
+        "qrcode": "^1.5.1"
       }
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/preact": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.4.1.tgz",
-      "integrity": "sha512-WKrRpCSwL2t3tpOOGhf2WfTpcmbpxaWtDbdJdKdjd0aEiTkvOmS4NBkG6kzlaAHI9AkQ3iVqbFWM3Ei7mZ4o1Q==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/qrcode": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.4.4.tgz",
-      "integrity": "sha512-oLzEC5+NKFou9P0bMj5+v6Z40evexeE29Z9cummZXZ9QXyMr3lphkURzxjXgPJC5azpxcshoDWV1xE46z+/c3Q==",
+    "node_modules/@walletconnect/legacy-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-provider/-/legacy-provider-2.0.0.tgz",
+      "integrity": "sha512-A8xPebMI1A+50HbWwTpFCbwP7G+1NGKdTKyg8BUUg3h3Y9JucpC1W6w/x0v1Xw7qFEqQnz74LoIN/A3ytH9xrQ==",
       "dependencies": {
-        "buffer": "^5.4.3",
-        "buffer-alloc": "^1.2.0",
-        "buffer-from": "^1.1.1",
-        "dijkstrajs": "^1.0.1",
-        "isarray": "^2.0.1",
-        "pngjs": "^3.3.0",
-        "yargs": "^13.2.4"
-      },
-      "bin": {
-        "qrcode": "bin/qrcode"
-      },
-      "engines": {
-        "node": ">=4"
+        "@walletconnect/jsonrpc-http-connection": "^1.0.4",
+        "@walletconnect/jsonrpc-provider": "^1.0.6",
+        "@walletconnect/legacy-client": "^2.0.0",
+        "@walletconnect/legacy-modal": "^2.0.0",
+        "@walletconnect/legacy-types": "^2.0.0",
+        "@walletconnect/legacy-utils": "^2.0.0"
       }
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+    "node_modules/@walletconnect/legacy-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-types/-/legacy-types-2.0.0.tgz",
+      "integrity": "sha512-sOVrA7HUdbI1OwKyPOQU0/DdvTSVFlsXWpAk2K2WvP2erTkBWPMTJq6cv2BmKdoJ3p6gLApT7sd+jHi3OF71uw==",
       "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "@walletconnect/jsonrpc-types": "^1.0.2"
       }
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+    "node_modules/@walletconnect/legacy-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-utils/-/legacy-utils-2.0.0.tgz",
+      "integrity": "sha512-CPWxSVVXw0kgNCxvU126g4GiV3mzXmC8IPJ15twE46aJ1FX+RHEIfAzFMFz2F2+fEhBxL63A7dwNQKDXorRPcQ==",
       "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "@walletconnect/encoding": "^1.0.2",
+        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/legacy-types": "^2.0.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "^5.3.0",
+        "query-string": "^6.13.5"
       }
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+    "node_modules/@walletconnect/logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-SsTKdsgWm+oDTBeNE/zHxxr5eJfZmE9/5yp/Ku+zJtcTAjELb3DXueWkDXmE9h8uHIbJzIb5wj5lPdzyrjT6hQ==",
       "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "pino": "7.11.0",
+        "tslib": "1.14.1"
       }
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+    "node_modules/@walletconnect/logger/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/modal": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.1.tgz",
+      "integrity": "sha512-G84tSzdPKAFk1zimgV7JzIUFT5olZUVtI3GcOk77OeLYjlMfnDT23RVRHm5EyCrjkptnvpD0wQScXePOFd2Xcw==",
       "dependencies": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
+        "@walletconnect/modal-core": "2.6.1",
+        "@walletconnect/modal-ui": "2.6.1"
       }
     },
-    "node_modules/@walletconnect/qrcode-modal/node_modules/yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+    "node_modules/@walletconnect/modal-core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.1.tgz",
+      "integrity": "sha512-f2hYlJ5pwzGvjyaZ6BoGR5uiMgXzWXt6w6ktt1N8lmY6PiYp8whZgqx2hTxVWwVlsGnaIfh6UHp1hGnANx0eTQ==",
       "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "valtio": "1.11.0"
+      }
+    },
+    "node_modules/@walletconnect/modal-ui": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.1.tgz",
+      "integrity": "sha512-RFUOwDAMijSK8B7W3+KoLKaa1l+KEUG0LCrtHqaB0H0cLnhEGdLR+kdTdygw+W8+yYZbkM5tXBm7MlFbcuyitA==",
+      "dependencies": {
+        "@walletconnect/modal-core": "2.6.1",
+        "lit": "2.7.6",
+        "motion": "10.16.2",
+        "qrcode": "1.5.3"
       }
     },
     "node_modules/@walletconnect/randombytes": {
@@ -10658,10 +10846,50 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@walletconnect/relay-api": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.9.tgz",
+      "integrity": "sha512-Q3+rylJOqRkO1D9Su0DPE3mmznbAalYapJ9qmzDgK28mYF9alcP3UwG/og5V7l7CFOqzCLi7B8BvcBUrpDj0Rg==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/relay-api/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/relay-auth": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.0.4.tgz",
+      "integrity": "sha512-kKJcS6+WxYq5kshpPaxGHdwf5y98ZwbfuS4EE/NkQzqrDFm5Cj+dP8LofzWvjrrLkZq7Afy7WrQMXdLy8Sx7HQ==",
+      "dependencies": {
+        "@stablelib/ed25519": "^1.0.2",
+        "@stablelib/random": "^1.0.1",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "tslib": "1.14.1",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/@walletconnect/safe-json": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.1.tgz",
-      "integrity": "sha512-Fm7e31oSYY15NQr8SsLJheKAy5L744udZf2lJKcz6wFmPJEzf7hOF0866o/rrldRzJnjZ4H2GJ45pFudsnLW5A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
@@ -10671,85 +10899,136 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@walletconnect/signer-connection": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/signer-connection/-/signer-connection-1.8.0.tgz",
-      "integrity": "sha512-+YAaTAP52MWZJ2wWnqKClKCPlPHBo6reURFe0cWidLADh9mi/kPWGALZ5AENK22zpem1bbKV466rF5Rzvu0ehA==",
+    "node_modules/@walletconnect/sign-client": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.9.0.tgz",
+      "integrity": "sha512-mEKc4LlLMebCe45qzqh+MX4ilQK4kOEBzLY6YJpG8EhyT45eX4JMNA7qQoYa9MRMaaVb/7USJcc4e3ZrjZvQmA==",
       "dependencies": {
-        "@walletconnect/client": "^1.8.0",
-        "@walletconnect/jsonrpc-types": "^1.0.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.3",
-        "@walletconnect/qrcode-modal": "^1.8.0",
-        "@walletconnect/types": "^1.8.0",
-        "eventemitter3": "4.0.7"
+        "@walletconnect/core": "2.9.0",
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
+        "events": "^3.3.0"
       }
     },
-    "node_modules/@walletconnect/socket-transport": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.8.0.tgz",
-      "integrity": "sha512-5DyIyWrzHXTcVp0Vd93zJ5XMW61iDM6bcWT4p8DTRfFsOtW46JquruMhxOLeCOieM4D73kcr3U7WtyR4JUsGuQ==",
+    "node_modules/@walletconnect/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
       "dependencies": {
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0",
-        "ws": "7.5.3"
+        "tslib": "1.14.1"
       }
     },
-    "node_modules/@walletconnect/socket-transport/node_modules/ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
+    "node_modules/@walletconnect/time/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/types": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.8.0.tgz",
-      "integrity": "sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
+      "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/logger": "^2.0.1",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.9.0.tgz",
+      "integrity": "sha512-k3nkSBkF69sJJVoe17IVoPtnhp/sgaa2t+x7BvA/BKeMxE0DGdtRJdEXotTc8DBmI7o2tkq6l8+HyFBGjQ/CjQ==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-http-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
+        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/sign-client": "2.9.0",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
+        "events": "^3.3.0"
+      }
     },
     "node_modules/@walletconnect/utils": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
-      "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
+      "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.8.0",
-        "@walletconnect/encoding": "^1.0.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.3",
-        "@walletconnect/types": "^1.8.0",
-        "bn.js": "4.11.8",
-        "js-sha3": "0.8.0",
-        "query-string": "6.13.5"
+        "@stablelib/chacha20poly1305": "1.0.1",
+        "@stablelib/hkdf": "1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha256": "1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "^3.1.0"
       }
     },
-    "node_modules/@walletconnect/utils/node_modules/bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    "node_modules/@walletconnect/utils/node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
     },
     "node_modules/@walletconnect/window-getters": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.0.tgz",
-      "integrity": "sha512-xB0SQsLaleIYIkSsl43vm8EwETpBzJ2gnzk7e0wMF3ktqiTGS6TFHxcprMl5R44KKh4tCcHCJwolMCaDSwtAaA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-getters/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/window-metadata": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.0.tgz",
-      "integrity": "sha512-9eFvmJxIKCC3YWOL97SgRkKhlyGXkrHwamfechmqszbypFspaSk+t2jQXAEU7YClHF6Qjw5eYOmy1//zFi9/GA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
       "dependencies": {
-        "@walletconnect/window-getters": "^1.0.0"
+        "@walletconnect/window-getters": "^1.0.1",
+        "tslib": "1.14.1"
       }
+    },
+    "node_modules/@walletconnect/window-metadata/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -11691,6 +11970,14 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/attr-accept": {
@@ -12712,25 +12999,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
-    },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-    },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -14242,10 +14510,9 @@
       "license": "MIT"
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
-      "license": "MIT",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "engines": {
         "node": ">=0.10"
       }
@@ -14422,9 +14689,9 @@
       }
     },
     "node_modules/detect-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
-      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -14731,6 +14998,17 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "license": "MIT"
     },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -14774,14 +15052,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
-    },
-    "node_modules/eip1193-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "dependencies": {
-        "@json-rpc-tools/provider": "^1.5.5"
-      }
     },
     "node_modules/ejs": {
       "version": "3.1.8",
@@ -16704,6 +16974,14 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
+    "node_modules/fast-redact": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -16919,6 +17197,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -21200,6 +21486,34 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lit": {
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.6.tgz",
+      "integrity": "sha512-1amFHA7t4VaaDe+vdQejSVBklwtH9svGoG6/dZi9JhxtJBBlqY5D1RV7iLUYY0trCqQc4NfhYYZilZiVHt7Hxg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.7.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -21280,6 +21594,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -21887,6 +22206,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/motion": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
+      "integrity": "sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==",
+      "dependencies": {
+        "@motionone/animation": "^10.15.1",
+        "@motionone/dom": "^10.16.2",
+        "@motionone/svelte": "^10.16.2",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "@motionone/vue": "^10.16.2"
+      }
+    },
+    "node_modules/motion/node_modules/@motionone/dom": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.16.2.tgz",
+      "integrity": "sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==",
+      "dependencies": {
+        "@motionone/animation": "^10.15.1",
+        "@motionone/generators": "^10.15.1",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/ms": {
@@ -22511,6 +22856,11 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -23043,6 +23393,41 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/pino": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.15.1"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dependencies": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "node_modules/pirates": {
       "version": "4.0.5",
@@ -24367,9 +24752,9 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.11.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
-      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "version": "10.17.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.1.tgz",
+      "integrity": "sha512-X9BODrvQ4Ekwv9GURm9AKAGaomqXmip7NQTZgY7gcNmr7XE83adOMJvd3N42id1tMFU7ojiynRsYnY6/BRFxLA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -24501,6 +24886,11 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
     "node_modules/promise": {
       "version": "8.1.0",
       "license": "MIT",
@@ -24615,6 +25005,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-compare": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.5.1.tgz",
+      "integrity": "sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA=="
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -24670,10 +25065,9 @@
       }
     },
     "node_modules/qrcode": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.1.tgz",
-      "integrity": "sha512-nS8NJ1Z3md8uTjKtP+SGGhfqmTCs5flU/xR623oI0JX+Wepz9R8UrRVCTBTJm3qGw3rH6jJ6MUHjkDx15cxSSg==",
-      "license": "MIT",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "encode-utf8": "^1.0.3",
@@ -24701,11 +25095,12 @@
       }
     },
     "node_modules/query-string": {
-      "version": "6.13.5",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
-      "integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       },
@@ -24752,6 +25147,11 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -25580,6 +25980,14 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/receptacle": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
@@ -26229,6 +26637,14 @@
       "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
       "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -26791,6 +27207,14 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -26932,6 +27356,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
@@ -27050,6 +27482,11 @@
         "readable-stream": "^3.6.0",
         "xtend": "^4.0.2"
       }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "node_modules/stream-transform": {
       "version": "3.2.0",
@@ -27813,6 +28250,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "license": "MIT"
+    },
+    "node_modules/thread-stream": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "dependencies": {
+        "real-require": "^0.1.0"
+      }
     },
     "node_modules/throat": {
       "version": "6.0.1",
@@ -28635,6 +29080,26 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/valtio": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.11.0.tgz",
+      "integrity": "sha512-65Yd0yU5qs86b5lN1eu/nzcTgQ9/6YnD6iO+DDaDbQLn1Zv2w12Gwk43WkPlUBxk5wL/6cD5YMFf7kj6HZ1Kpg==",
+      "dependencies": {
+        "proxy-compare": "2.5.1",
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
@@ -28730,13 +29195,13 @@
       }
     },
     "node_modules/wagmi": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.9.5.tgz",
-      "integrity": "sha512-vmweVRVk3iKz0G5aCN5qW4H1OeFgP3h7YJqny/dTXZnnPl1pYHJHukl/gq7WwoDAQYI25PxwCmxy3sbIYKLTNA==",
+      "version": "0.12.19",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.12.19.tgz",
+      "integrity": "sha512-S/el9BDb/HNeQWh1v8TvntMPX/CgKLDAoJqDb8i7jifLfWPqFL7gor3vnI1Vs6ZlB8uh7m+K1Qyg+mKhbITuDQ==",
       "funding": [
         {
           "type": "gitcoin",
-          "url": "https://gitcoin.co/grants/4493/wagmi-react-hooks-library-for-ethereum"
+          "url": "https://wagmi.sh/gitcoin"
         },
         {
           "type": "github",
@@ -28744,18 +29209,45 @@
         }
       ],
       "dependencies": {
-        "@coinbase/wallet-sdk": "^3.6.0",
-        "@tanstack/query-sync-storage-persister": "^4.14.5",
-        "@tanstack/react-query": "^4.14.5",
-        "@tanstack/react-query-persist-client": "^4.14.5",
-        "@wagmi/core": "0.8.5",
-        "@walletconnect/ethereum-provider": "^1.8.0",
-        "abitype": "^0.2.5",
+        "@tanstack/query-sync-storage-persister": "^4.27.1",
+        "@tanstack/react-query": "^4.28.0",
+        "@tanstack/react-query-persist-client": "^4.28.0",
+        "@wagmi/core": "0.10.17",
+        "abitype": "^0.3.0",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
-        "ethers": ">=5.5.1",
-        "react": ">=17.0.0"
+        "ethers": ">=5.5.1 <6",
+        "react": ">=17.0.0",
+        "typescript": ">=4.9.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wagmi/node_modules/abitype": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.3.0.tgz",
+      "integrity": "sha512-0YokyAV4hKMcy97Pl+6QgZBlBdZJN2llslOs7kiFY+cu7kMlVXDBpxMExfv0krzBCQt2t7hNovpQ3y/zvEm18A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "engines": {
+        "pnpm": ">=7"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.4",
+        "zod": ">=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/walker": {
@@ -29920,9 +30412,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.1.5.tgz",
-      "integrity": "sha512-PsdRT8Bvq22Yyh1tvpgdHNE7OAeFKqJXUxtJvj1Ixw2B9O2YZ1M34ImQ+xyZah4wZrR4lENMoDUutKPpyXCQ/Q==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
+      "integrity": "sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==",
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },
@@ -29930,10 +30422,14 @@
         "node": ">=12.7.0"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8",
         "immer": ">=9.0",
         "react": ">=16.8"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
         "immer": {
           "optional": true
         },
@@ -32541,9 +33037,9 @@
       "integrity": "sha512-WWULIiucYRBIewHKFA7BssQ2ABLHLVd9lrUo3N3SZgR0u4ZRDDVEUNOy+r+9ruDze8+36dGbN9wsN1IdELtdOw=="
     },
     "@coinbase/wallet-sdk": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.6.3.tgz",
-      "integrity": "sha512-XUR4poOJE+dKzwBTdlM693CdLFitr046oZOVY3iDnbFcRrrQswhbDji7q4CmUcD4HxbfViX7PFoIwl79YQcukg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.7.1.tgz",
+      "integrity": "sha512-LjyoDCB+7p0waQXfK+fUgcAs3Ezk6S6e+LYaoFjpJ6c9VTop3NyZF40Pi7df4z7QJohCwzuIDjz0Rhtig6Y7Pg==",
       "requires": {
         "@metamask/safe-event-emitter": "2.0.0",
         "@solana/web3.js": "^1.70.1",
@@ -32551,8 +33047,8 @@
         "bn.js": "^5.1.1",
         "buffer": "^6.0.3",
         "clsx": "^1.1.0",
-        "eth-block-tracker": "4.4.3",
-        "eth-json-rpc-filters": "4.2.2",
+        "eth-block-tracker": "6.1.0",
+        "eth-json-rpc-filters": "5.1.0",
         "eth-rpc-errors": "4.0.2",
         "json-rpc-engine": "6.1.0",
         "keccak": "^3.0.1",
@@ -32568,6 +33064,36 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
           "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        },
+        "eth-block-tracker": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-6.1.0.tgz",
+          "integrity": "sha512-K9SY8+/xMBi4M5HHTDdxnpEqEEGjbNpzHFqvxyjMZej8InV/B+CkFRKM6W+uvrFJ7m8Zd1E0qUkseU3vdIDFYQ==",
+          "requires": {
+            "@metamask/safe-event-emitter": "^2.0.0",
+            "@metamask/utils": "^3.0.1",
+            "json-rpc-random-id": "^1.0.1",
+            "pify": "^3.0.0"
+          }
+        },
+        "eth-json-rpc-filters": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-5.1.0.tgz",
+          "integrity": "sha512-fos+9xmoa1A2Ytsc9eYof17r81BjdJOUcGcgZn4K/tKdCCTb+a8ytEtwlu1op5qsXFDlgGmstTELFrDEc89qEQ==",
+          "requires": {
+            "@metamask/safe-event-emitter": "^2.0.0",
+            "async-mutex": "^0.2.6",
+            "eth-query": "^2.1.2",
+            "json-rpc-engine": "^6.1.0",
+            "pify": "^5.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+              "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
+            }
+          }
         },
         "eth-rpc-errors": {
           "version": "4.0.2",
@@ -33552,48 +34078,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@json-rpc-tools/provider": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "requires": {
-        "@json-rpc-tools/utils": "^1.7.6",
-        "axios": "^0.21.0",
-        "safe-json-utils": "^1.1.1",
-        "ws": "^7.4.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        }
-      }
-    },
-    "@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "requires": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "requires": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "@ledgerhq/connect-kit-loader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.0.2.tgz",
-      "integrity": "sha512-TQ21IjcZOw/scqypaVFY3jHVqI7X7Hta3qN/us6FvTol3AY06UmrhhXGww0E9xHmAbdX241ddwXEiMBSQZFr9g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.2.tgz",
+      "integrity": "sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A=="
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -34988,17 +35476,58 @@
         }
       }
     },
+    "@lit-labs/ssr-dom-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
+      "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
+    },
+    "@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
     "@metamask/safe-event-emitter": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
       "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
     },
-    "@motionone/animation": {
-      "version": "10.13.2",
+    "@metamask/utils": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-3.6.0.tgz",
+      "integrity": "sha512-9cIRrfkWvHblSiNDVXsjivqa9Ak0RYo/1H6tqTqTbAx+oBK2Sva0lWDHxGchOqA7bySGUJKAWSNJvH6gdHZ0gQ==",
       "requires": {
-        "@motionone/easing": "^10.13.2",
-        "@motionone/types": "^10.13.2",
-        "@motionone/utils": "^10.13.2",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "semver": "^7.3.8",
+        "superstruct": "^1.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "superstruct": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
+          "integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg=="
+        }
+      }
+    },
+    "@motionone/animation": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
+      "integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
+      "requires": {
+        "@motionone/easing": "^10.15.1",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
         "tslib": "^2.3.1"
       }
     },
@@ -35016,29 +35545,85 @@
       }
     },
     "@motionone/easing": {
-      "version": "10.13.2",
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
+      "integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
       "requires": {
-        "@motionone/utils": "^10.13.2",
+        "@motionone/utils": "^10.15.1",
         "tslib": "^2.3.1"
       }
     },
     "@motionone/generators": {
-      "version": "10.13.2",
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
+      "integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
       "requires": {
-        "@motionone/types": "^10.13.2",
-        "@motionone/utils": "^10.13.2",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
         "tslib": "^2.3.1"
       }
     },
+    "@motionone/svelte": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.2.tgz",
+      "integrity": "sha512-38xsroKrfK+aHYhuQlE6eFcGy0EwrB43Q7RGjF73j/kRUTcLNu/LAaKiLLsN5lyqVzCgTBVt4TMT/ShWbTbc5Q==",
+      "requires": {
+        "@motionone/dom": "^10.16.2",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@motionone/dom": {
+          "version": "10.16.2",
+          "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.16.2.tgz",
+          "integrity": "sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==",
+          "requires": {
+            "@motionone/animation": "^10.15.1",
+            "@motionone/generators": "^10.15.1",
+            "@motionone/types": "^10.15.1",
+            "@motionone/utils": "^10.15.1",
+            "hey-listen": "^1.0.8",
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
     "@motionone/types": {
-      "version": "10.13.2"
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
+      "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
     },
     "@motionone/utils": {
-      "version": "10.13.2",
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
+      "integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
       "requires": {
-        "@motionone/types": "^10.13.2",
+        "@motionone/types": "^10.15.1",
         "hey-listen": "^1.0.8",
         "tslib": "^2.3.1"
+      }
+    },
+    "@motionone/vue": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.2.tgz",
+      "integrity": "sha512-7/dEK/nWQXOkJ70bqb2KyNfSWbNvWqKKq1C8juj+0Mg/AorgD8O5wE3naddK0G+aXuNMqRuc4jlsYHHWHtIzVw==",
+      "requires": {
+        "@motionone/dom": "^10.16.2",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@motionone/dom": {
+          "version": "10.16.2",
+          "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.16.2.tgz",
+          "integrity": "sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==",
+          "requires": {
+            "@motionone/animation": "^10.15.1",
+            "@motionone/generators": "^10.15.1",
+            "@motionone/types": "^10.15.1",
+            "@motionone/utils": "^10.15.1",
+            "hey-listen": "^1.0.8",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@multiformats/mafmt": {
@@ -35402,11 +35987,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
-    },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.7",
       "requires": {
@@ -35541,9 +36121,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@rainbow-me/rainbowkit": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-0.8.1.tgz",
-      "integrity": "sha512-A8BjihvgCY/xjQWOpqgOce+uO4mmIV4Qlo3XMF87kk5WNmyLLaPx2oYTJQz1uOinWE77h4G0HozJr5wnrermgw==",
+      "version": "0.12.18",
+      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-0.12.18.tgz",
+      "integrity": "sha512-Ehpr8gBCS8v4vdXLi8ZBlQ1yA6GHJOhoP66hLrdgI5iSlr6aUGTEicEfb2RaKNltHJFW/5A4BKst0AK4PkAkuw==",
       "requires": {
         "@vanilla-extract/css": "1.9.1",
         "@vanilla-extract/dynamic": "2.0.2",
@@ -35775,6 +36355,43 @@
     },
     "@rushstack/eslint-patch": {
       "version": "1.1.4"
+    },
+    "@safe-global/safe-apps-provider": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.15.2.tgz",
+      "integrity": "sha512-BaoGAuY7h6jLBL7P+M6b7hd+1QfTv8uMyNF3udhiNUwA0XwfzH2ePQB13IEV3Mn7wdcIMEEUDS5kHbtAsj60qQ==",
+      "requires": {
+        "@safe-global/safe-apps-sdk": "7.9.0",
+        "events": "^3.3.0"
+      },
+      "dependencies": {
+        "@safe-global/safe-apps-sdk": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-7.9.0.tgz",
+          "integrity": "sha512-S2EI+JL8ocSgE3uGNaDZCzKmwfhtxXZFDUP76vN0FeaY35itFMyi8F0Vhxu0XnZm3yLzJE3tp5px6GhuQFLU6w==",
+          "requires": {
+            "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
+            "ethers": "^5.7.2"
+          }
+        }
+      }
+    },
+    "@safe-global/safe-apps-sdk": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-7.11.0.tgz",
+      "integrity": "sha512-RDamzPM1Lhhiiz0O+Dn6FkFqIh47jmZX+HCV/BBnBBOSKfBJE//IGD3+02zMgojXHTikQAburdPes9qmH1SA1A==",
+      "requires": {
+        "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
+        "ethers": "^5.7.2"
+      }
+    },
+    "@safe-global/safe-gateway-typescript-sdk": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.10.0.tgz",
+      "integrity": "sha512-nhWjFRRgrGz4uZbyQ3Hgm4si1AixCWlnvi5WUCq/+V+e8EoA2Apj9xJEt8zzXvtELlddFqkH2sfTFy9LIjGXKg==",
+      "requires": {
+        "cross-fetch": "^3.1.5"
+      }
     },
     "@sarcophagus-org/sarcophagus-v2-contracts": {
       "version": "0.17.2",
@@ -36279,6 +36896,41 @@
       "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
       "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
     },
+    "@stablelib/ed25519": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
+      "integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
+      "requires": {
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha512": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/hash": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
+      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
+    },
+    "@stablelib/hkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
+      "integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
+      "requires": {
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/hmac": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/hmac": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
+      "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
+      "requires": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
     "@stablelib/int": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
@@ -36307,6 +36959,26 @@
       "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
       "requires": {
         "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/sha256": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
+      "integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
+      "requires": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/sha512": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
+      "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
+      "requires": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
@@ -36472,38 +37144,41 @@
       }
     },
     "@tanstack/query-core": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.20.4.tgz",
-      "integrity": "sha512-lhLtGVNJDsJ/DyZXrLzekDEywQqRVykgBqTmkv0La32a/RleILXy6JMLBb7UmS3QCatg/F/0N9/5b0i5j6IKcA=="
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.33.0.tgz",
+      "integrity": "sha512-qYu73ptvnzRh6se2nyBIDHGBQvPY1XXl3yR769B7B6mIDD7s+EZhdlWHQ67JI6UOTFRaI7wupnTnwJ3gE0Mr/g=="
     },
     "@tanstack/query-persist-client-core": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-4.20.4.tgz",
-      "integrity": "sha512-MzrRC9esSEpD/kY28Zi4YqkWvuOUmpO67vpgCkQszOLbAHLMeEibId3njXxIZXDPg5fvX3HaAwFS7GheuMuKFg=="
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-4.33.0.tgz",
+      "integrity": "sha512-3P16+2JjcUU5CHi10jJuwd0ZQYvQtSuzLvCUCjVuAnj3GZjfSso1v8t6WAObAr9RPuIC6vDXeOQ3mr07EF/NxQ==",
+      "requires": {
+        "@tanstack/query-core": "4.33.0"
+      }
     },
     "@tanstack/query-sync-storage-persister": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-4.20.4.tgz",
-      "integrity": "sha512-+LrpqZDScy9FfyJJGSY6/sMbgi9zHbDCXWOwpKJ2aPfTblk0cAJDjlM7rS49FXZD//edEJehm9SgRhFN2/9pSg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-4.33.0.tgz",
+      "integrity": "sha512-V6igMcdEOXPRpvmNFQ6I/iJaw9NhxWy7x8PWamm2cgSsLi8bHaDvUVuWkZm+ikI47QjoCUk7qll/82JYLaH+pw==",
       "requires": {
-        "@tanstack/query-persist-client-core": "4.20.4"
+        "@tanstack/query-persist-client-core": "4.33.0"
       }
     },
     "@tanstack/react-query": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.20.4.tgz",
-      "integrity": "sha512-SJRxx13k/csb9lXAJfycgVA1N/yU/h3bvRNWP0+aHMfMjmbyX82FdoAcckDBbOdEyAupvb0byelNHNeypCFSyA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.33.0.tgz",
+      "integrity": "sha512-97nGbmDK0/m0B86BdiXzx3EW9RcDYKpnyL2+WwyuLHEgpfThYAnXFaMMmnTDuAO4bQJXEhflumIEUfKmP7ESGA==",
       "requires": {
-        "@tanstack/query-core": "4.20.4",
+        "@tanstack/query-core": "4.33.0",
         "use-sync-external-store": "^1.2.0"
       }
     },
     "@tanstack/react-query-persist-client": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-4.20.4.tgz",
-      "integrity": "sha512-fJvYdULQEa+PV7M3WzWNPWiP/VmWflyiISwIzu2/wC6TnsH7CzXwUwy5PvTl89AR26GR0/U5J6f+oS6JhLVJxQ==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-4.33.0.tgz",
+      "integrity": "sha512-B3q0r1tqTTSkd9vctyqFj28xdGZJ+Dnr/7H05Ta1JF1w7EauVQl8ILrmXADecwvILnr1xoZO6lvi2W+mZxMinw==",
       "requires": {
-        "@tanstack/query-persist-client-core": "4.20.4"
+        "@tanstack/query-persist-client-core": "4.33.0"
       }
     },
     "@tootallnate/once": {
@@ -36602,6 +37277,14 @@
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "requires": {
+        "@types/ms": "*"
       }
     },
     "@types/eslint": {
@@ -36748,6 +37431,11 @@
       "requires": {
         "moment": "*"
       }
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
       "version": "16.11.49"
@@ -37087,74 +37775,83 @@
       "integrity": "sha512-ZYyrkx5k4Eoy2WM63TYTOPwiNFrylCMPhR3rjMiSHjrB5Sh97bPPU0z1EtxzDkZJJxVxmb09kQdeBrs/Mwkd3w=="
     },
     "@wagmi/connectors": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-0.1.2.tgz",
-      "integrity": "sha512-YfhZMQMqBl69xbhs5rokGjAVfKN9Ynlsw4SgU/BGuxKpHY9VRWUGAEhgpHRTVcs72qBick3HNQv4wuFqx0Z1CQ==",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-0.3.24.tgz",
+      "integrity": "sha512-1pI0G9HRblc651dCz9LXuEu/zWQk23XwOUYqJEINb/c2TTLtw5TnTRIcefxxK6RnxeJvcKfnmK0rdZp/4ujFAA==",
       "requires": {
-        "@coinbase/wallet-sdk": "^3.5.4",
+        "@coinbase/wallet-sdk": "^3.6.6",
         "@ledgerhq/connect-kit-loader": "^1.0.1",
-        "@walletconnect/ethereum-provider": "^1.8.0",
-        "abitype": "^0.1.8",
+        "@safe-global/safe-apps-provider": "^0.15.2",
+        "@safe-global/safe-apps-sdk": "^7.9.0",
+        "@walletconnect/ethereum-provider": "2.9.0",
+        "@walletconnect/legacy-provider": "^2.0.0",
+        "@walletconnect/modal": "^2.5.9",
+        "abitype": "^0.3.0",
         "eventemitter3": "^4.0.7"
       },
       "dependencies": {
         "abitype": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.1.8.tgz",
-          "integrity": "sha512-2pde0KepTzdfu19ZrzYTYVIWo69+6UbBCY4B1RDiwWgo2XZtFSJhF6C+XThuRXbbZ823J0Rw1Y5cP0NXYVcCdQ=="
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.3.0.tgz",
+          "integrity": "sha512-0YokyAV4hKMcy97Pl+6QgZBlBdZJN2llslOs7kiFY+cu7kMlVXDBpxMExfv0krzBCQt2t7hNovpQ3y/zvEm18A=="
         }
       }
     },
     "@wagmi/core": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.8.5.tgz",
-      "integrity": "sha512-+oUQvJTs81QeD/vXqrhCSNVIiQy27yeHFiCWeDrvYZNyagp+8JO3wDom0pEd4UqEqhzHvFzAcHTmPWEq88B5uA==",
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.10.17.tgz",
+      "integrity": "sha512-qud45y3IlHp7gYWzoFeyysmhyokRie59Xa5tcx5F1E/v4moD5BY0kzD26mZW/ZQ3WZuVK/lZwiiPRqpqWH52Gw==",
       "requires": {
-        "@wagmi/chains": "0.1.5",
-        "@wagmi/connectors": "0.1.2",
-        "abitype": "^0.2.5",
+        "@wagmi/chains": "0.2.22",
+        "@wagmi/connectors": "0.3.24",
+        "abitype": "^0.3.0",
         "eventemitter3": "^4.0.7",
-        "zustand": "^4.1.4"
-      }
-    },
-    "@walletconnect/browser-utils": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz",
-      "integrity": "sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==",
-      "requires": {
-        "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/window-getters": "1.0.0",
-        "@walletconnect/window-metadata": "1.0.0",
-        "detect-browser": "5.2.0"
+        "zustand": "^4.3.1"
       },
       "dependencies": {
-        "@walletconnect/safe-json": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.0.tgz",
-          "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
+        "@wagmi/chains": {
+          "version": "0.2.22",
+          "resolved": "https://registry.npmjs.org/@wagmi/chains/-/chains-0.2.22.tgz",
+          "integrity": "sha512-TdiOzJT6TO1JrztRNjTA5Quz+UmQlbvWFG8N41u9tta0boHA1JCAzGGvU6KuIcOmJfRJkKOUIt67wlbopCpVHg=="
+        },
+        "abitype": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.3.0.tgz",
+          "integrity": "sha512-0YokyAV4hKMcy97Pl+6QgZBlBdZJN2llslOs7kiFY+cu7kMlVXDBpxMExfv0krzBCQt2t7hNovpQ3y/zvEm18A=="
         }
       }
     },
-    "@walletconnect/client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.8.0.tgz",
-      "integrity": "sha512-svyBQ14NHx6Cs2j4TpkQaBI/2AF4+LXz64FojTjMtV4VMMhl81jSO1vNeg+yYhQzvjcGH/GpSwixjyCW0xFBOQ==",
-      "requires": {
-        "@walletconnect/core": "^1.8.0",
-        "@walletconnect/iso-crypto": "^1.8.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0"
-      }
-    },
     "@walletconnect/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-aFTHvEEbXcZ8XdWBw6rpQDte41Rxwnuk3SgTD8/iKGSRTni50gI9S3YEzMj05jozSiOBxQci4pJDMVhIUMtarw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-MZYJghS9YCvGe32UOgDj0mCasaOoGHQaYXWeQblXE/xb8HuaM6kAWhjIQN9P+MNp5QP134BHP5olQostcCotXQ==",
       "requires": {
-        "@walletconnect/socket-transport": "^1.8.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0"
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.12",
+        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/relay-auth": "^1.0.4",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
+        "events": "^3.3.0",
+        "lodash.isequal": "4.5.0",
+        "uint8arrays": "^3.1.0"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        }
       }
     },
     "@walletconnect/crypto": {
@@ -37215,36 +37912,60 @@
       }
     },
     "@walletconnect/ethereum-provider": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-1.8.0.tgz",
-      "integrity": "sha512-Nq9m+oo5P0F+njsROHw9KMWdoc/8iGHYzQdkjJN/1C7DtsqFRg5k5a3hd9rzCLpbPsOC1q8Z5lRs6JQgDvPm6Q==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.9.0.tgz",
+      "integrity": "sha512-rSXkC0SXMigJRdIi/M2RMuEuATY1AwtlTWQBnqyxoht7xbO2bQNPCXn0XL4s/GRNrSUtoKSY4aPMHXV4W4yLBA==",
       "requires": {
-        "@walletconnect/client": "^1.8.0",
-        "@walletconnect/jsonrpc-http-connection": "^1.0.2",
-        "@walletconnect/jsonrpc-provider": "^1.0.5",
-        "@walletconnect/signer-connection": "^1.8.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0",
-        "eip1193-provider": "1.0.1",
-        "eventemitter3": "4.0.7"
+        "@walletconnect/jsonrpc-http-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "^1.0.13",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/sign-client": "2.9.0",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/universal-provider": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
+        "events": "^3.3.0"
       }
     },
-    "@walletconnect/iso-crypto": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.8.0.tgz",
-      "integrity": "sha512-pWy19KCyitpfXb70hA73r9FcvklS+FvO9QUIttp3c2mfW8frxgYeRXfxLRCIQTkaYueRKvdqPjbyhPLam508XQ==",
+    "@walletconnect/events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
       "requires": {
-        "@walletconnect/crypto": "^1.0.2",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0"
+        "keyvaluestorage-interface": "^1.0.0",
+        "tslib": "1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@walletconnect/heartbeat": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
+      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
+      "requires": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "tslib": "1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@walletconnect/jsonrpc-http-connection": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.4.tgz",
-      "integrity": "sha512-ji79pspdBhmIbTwve383tMaDu5Le9plW+oj5GE2aqzxIl3ib8JvRBZRn5lGEBGqVCvqB3MBJL7gBlEwpyRtoxQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.7.tgz",
+      "integrity": "sha512-qlfh8fCfu8LOM9JRR9KE0s0wxP6ZG9/Jom8M0qsoIQeKF3Ni0FyV4V1qy/cc7nfI46SLQLSl4tgWSfLiE1swyQ==",
       "requires": {
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
         "cross-fetch": "^3.1.4",
         "tslib": "1.14.1"
@@ -37258,12 +37979,12 @@
       }
     },
     "@walletconnect/jsonrpc-provider": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.6.tgz",
-      "integrity": "sha512-f5vQxr53vUVQ51/9mRLb1OiNciT/546XZ68Byn9OYnDBGeGJXK2kQWDHp8sPWZbN5x0p7B6asdCWMVFJ6danlw==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
+      "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
       "requires": {
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/safe-json": "^1.0.2",
         "tslib": "1.14.1"
       },
       "dependencies": {
@@ -37275,9 +37996,9 @@
       }
     },
     "@walletconnect/jsonrpc-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.2.tgz",
-      "integrity": "sha512-CZe8tjJX73OWdHjrBHy7HtAapJ2tT0Q3TYhPBhRxi3643lwPIQWC9En45ldY14TZwgSewkbZ0FtGBZK0G7Bbyg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
       "requires": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -37291,12 +38012,12 @@
       }
     },
     "@walletconnect/jsonrpc-utils": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.4.tgz",
-      "integrity": "sha512-y0+tDxcTZ9BHBBKBJbjZxLUXb+zQZCylf7y/jTvDPNx76J0hYYc+F9zHzyqBLeorSKepLTk6yI8hw3NXbAQB3g==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
       "requires": {
         "@walletconnect/environment": "^1.0.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
         "tslib": "1.14.1"
       },
       "dependencies": {
@@ -37307,187 +38028,148 @@
         }
       }
     },
-    "@walletconnect/mobile-registry": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/mobile-registry/-/mobile-registry-1.4.0.tgz",
-      "integrity": "sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw=="
-    },
-    "@walletconnect/qrcode-modal": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.8.0.tgz",
-      "integrity": "sha512-BueaFefaAi8mawE45eUtztg3ZFbsAH4DDXh1UNwdUlsvFMjqcYzLUG0xZvDd6z2eOpbgDg2N3bl6gF0KONj1dg==",
+    "@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
+      "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
       "requires": {
-        "@walletconnect/browser-utils": "^1.8.0",
-        "@walletconnect/mobile-registry": "^1.4.0",
-        "@walletconnect/types": "^1.8.0",
-        "copy-to-clipboard": "^3.3.1",
-        "preact": "10.4.1",
-        "qrcode": "1.4.4"
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "tslib": "1.14.1",
+        "ws": "^7.5.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="
-        },
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "pngjs": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-          "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
-        },
-        "preact": {
-          "version": "10.4.1",
-          "resolved": "https://registry.npmjs.org/preact/-/preact-10.4.1.tgz",
-          "integrity": "sha512-WKrRpCSwL2t3tpOOGhf2WfTpcmbpxaWtDbdJdKdjd0aEiTkvOmS4NBkG6kzlaAHI9AkQ3iVqbFWM3Ei7mZ4o1Q=="
-        },
-        "qrcode": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.4.4.tgz",
-          "integrity": "sha512-oLzEC5+NKFou9P0bMj5+v6Z40evexeE29Z9cummZXZ9QXyMr3lphkURzxjXgPJC5azpxcshoDWV1xE46z+/c3Q==",
-          "requires": {
-            "buffer": "^5.4.3",
-            "buffer-alloc": "^1.2.0",
-            "buffer-from": "^1.1.1",
-            "dijkstrajs": "^1.0.1",
-            "isarray": "^2.0.1",
-            "pngjs": "^3.3.0",
-            "yargs": "^13.2.4"
-          }
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.3.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
+      }
+    },
+    "@walletconnect/keyvaluestorage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.0.2.tgz",
+      "integrity": "sha512-U/nNG+VLWoPFdwwKx0oliT4ziKQCEoQ27L5Hhw8YOFGA2Po9A9pULUYNWhDgHkrb0gYDNt//X7wABcEWWBd3FQ==",
+      "requires": {
+        "safe-json-utils": "^1.1.1",
+        "tslib": "1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@walletconnect/legacy-client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-client/-/legacy-client-2.0.0.tgz",
+      "integrity": "sha512-v5L7rYk9loVnfvUf0mF+76bUPFaU5/Vh7mzL6/950CD/yoGdzYZ3Kj+L7mkC6HPMEGeQsBP1+sqBuiVGZ/aODA==",
+      "requires": {
+        "@walletconnect/crypto": "^1.0.3",
+        "@walletconnect/encoding": "^1.0.2",
+        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/legacy-types": "^2.0.0",
+        "@walletconnect/legacy-utils": "^2.0.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "^5.3.0",
+        "query-string": "^6.13.5"
+      }
+    },
+    "@walletconnect/legacy-modal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-modal/-/legacy-modal-2.0.0.tgz",
+      "integrity": "sha512-jckNd8lMhm4X7dX9TDdxM3bXKJnaqkRs6K2Mo5j6GmbIF9Eyx40jZ5+q457RVxvM6ciZEDT5s1wBHWdWoOo+9Q==",
+      "requires": {
+        "@walletconnect/legacy-types": "^2.0.0",
+        "@walletconnect/legacy-utils": "^2.0.0",
+        "copy-to-clipboard": "^3.3.3",
+        "preact": "^10.12.0",
+        "qrcode": "^1.5.1"
+      }
+    },
+    "@walletconnect/legacy-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-provider/-/legacy-provider-2.0.0.tgz",
+      "integrity": "sha512-A8xPebMI1A+50HbWwTpFCbwP7G+1NGKdTKyg8BUUg3h3Y9JucpC1W6w/x0v1Xw7qFEqQnz74LoIN/A3ytH9xrQ==",
+      "requires": {
+        "@walletconnect/jsonrpc-http-connection": "^1.0.4",
+        "@walletconnect/jsonrpc-provider": "^1.0.6",
+        "@walletconnect/legacy-client": "^2.0.0",
+        "@walletconnect/legacy-modal": "^2.0.0",
+        "@walletconnect/legacy-types": "^2.0.0",
+        "@walletconnect/legacy-utils": "^2.0.0"
+      }
+    },
+    "@walletconnect/legacy-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-types/-/legacy-types-2.0.0.tgz",
+      "integrity": "sha512-sOVrA7HUdbI1OwKyPOQU0/DdvTSVFlsXWpAk2K2WvP2erTkBWPMTJq6cv2BmKdoJ3p6gLApT7sd+jHi3OF71uw==",
+      "requires": {
+        "@walletconnect/jsonrpc-types": "^1.0.2"
+      }
+    },
+    "@walletconnect/legacy-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-utils/-/legacy-utils-2.0.0.tgz",
+      "integrity": "sha512-CPWxSVVXw0kgNCxvU126g4GiV3mzXmC8IPJ15twE46aJ1FX+RHEIfAzFMFz2F2+fEhBxL63A7dwNQKDXorRPcQ==",
+      "requires": {
+        "@walletconnect/encoding": "^1.0.2",
+        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/legacy-types": "^2.0.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "^5.3.0",
+        "query-string": "^6.13.5"
+      }
+    },
+    "@walletconnect/logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-SsTKdsgWm+oDTBeNE/zHxxr5eJfZmE9/5yp/Ku+zJtcTAjELb3DXueWkDXmE9h8uHIbJzIb5wj5lPdzyrjT6hQ==",
+      "requires": {
+        "pino": "7.11.0",
+        "tslib": "1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@walletconnect/modal": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.1.tgz",
+      "integrity": "sha512-G84tSzdPKAFk1zimgV7JzIUFT5olZUVtI3GcOk77OeLYjlMfnDT23RVRHm5EyCrjkptnvpD0wQScXePOFd2Xcw==",
+      "requires": {
+        "@walletconnect/modal-core": "2.6.1",
+        "@walletconnect/modal-ui": "2.6.1"
+      }
+    },
+    "@walletconnect/modal-core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.1.tgz",
+      "integrity": "sha512-f2hYlJ5pwzGvjyaZ6BoGR5uiMgXzWXt6w6ktt1N8lmY6PiYp8whZgqx2hTxVWwVlsGnaIfh6UHp1hGnANx0eTQ==",
+      "requires": {
+        "valtio": "1.11.0"
+      }
+    },
+    "@walletconnect/modal-ui": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.1.tgz",
+      "integrity": "sha512-RFUOwDAMijSK8B7W3+KoLKaa1l+KEUG0LCrtHqaB0H0cLnhEGdLR+kdTdygw+W8+yYZbkM5tXBm7MlFbcuyitA==",
+      "requires": {
+        "@walletconnect/modal-core": "2.6.1",
+        "lit": "2.7.6",
+        "motion": "10.16.2",
+        "qrcode": "1.5.3"
       }
     },
     "@walletconnect/randombytes": {
@@ -37508,10 +38190,54 @@
         }
       }
     },
+    "@walletconnect/relay-api": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.9.tgz",
+      "integrity": "sha512-Q3+rylJOqRkO1D9Su0DPE3mmznbAalYapJ9qmzDgK28mYF9alcP3UwG/og5V7l7CFOqzCLi7B8BvcBUrpDj0Rg==",
+      "requires": {
+        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "tslib": "1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@walletconnect/relay-auth": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.0.4.tgz",
+      "integrity": "sha512-kKJcS6+WxYq5kshpPaxGHdwf5y98ZwbfuS4EE/NkQzqrDFm5Cj+dP8LofzWvjrrLkZq7Afy7WrQMXdLy8Sx7HQ==",
+      "requires": {
+        "@stablelib/ed25519": "^1.0.2",
+        "@stablelib/random": "^1.0.1",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "tslib": "1.14.1",
+        "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        }
+      }
+    },
     "@walletconnect/safe-json": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.1.tgz",
-      "integrity": "sha512-Fm7e31oSYY15NQr8SsLJheKAy5L744udZf2lJKcz6wFmPJEzf7hOF0866o/rrldRzJnjZ4H2GJ45pFudsnLW5A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "requires": {
         "tslib": "1.14.1"
       },
@@ -37523,73 +38249,137 @@
         }
       }
     },
-    "@walletconnect/signer-connection": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/signer-connection/-/signer-connection-1.8.0.tgz",
-      "integrity": "sha512-+YAaTAP52MWZJ2wWnqKClKCPlPHBo6reURFe0cWidLADh9mi/kPWGALZ5AENK22zpem1bbKV466rF5Rzvu0ehA==",
+    "@walletconnect/sign-client": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.9.0.tgz",
+      "integrity": "sha512-mEKc4LlLMebCe45qzqh+MX4ilQK4kOEBzLY6YJpG8EhyT45eX4JMNA7qQoYa9MRMaaVb/7USJcc4e3ZrjZvQmA==",
       "requires": {
-        "@walletconnect/client": "^1.8.0",
-        "@walletconnect/jsonrpc-types": "^1.0.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.3",
-        "@walletconnect/qrcode-modal": "^1.8.0",
-        "@walletconnect/types": "^1.8.0",
-        "eventemitter3": "4.0.7"
+        "@walletconnect/core": "2.9.0",
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
+        "events": "^3.3.0"
       }
     },
-    "@walletconnect/socket-transport": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.8.0.tgz",
-      "integrity": "sha512-5DyIyWrzHXTcVp0Vd93zJ5XMW61iDM6bcWT4p8DTRfFsOtW46JquruMhxOLeCOieM4D73kcr3U7WtyR4JUsGuQ==",
+    "@walletconnect/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
       "requires": {
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0",
-        "ws": "7.5.3"
+        "tslib": "1.14.1"
       },
       "dependencies": {
-        "ws": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-          "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@walletconnect/types": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.8.0.tgz",
-      "integrity": "sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
+      "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
+      "requires": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/logger": "^2.0.1",
+        "events": "^3.3.0"
+      }
+    },
+    "@walletconnect/universal-provider": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.9.0.tgz",
+      "integrity": "sha512-k3nkSBkF69sJJVoe17IVoPtnhp/sgaa2t+x7BvA/BKeMxE0DGdtRJdEXotTc8DBmI7o2tkq6l8+HyFBGjQ/CjQ==",
+      "requires": {
+        "@walletconnect/jsonrpc-http-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
+        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/sign-client": "2.9.0",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
+        "events": "^3.3.0"
+      }
     },
     "@walletconnect/utils": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
-      "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
+      "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
       "requires": {
-        "@walletconnect/browser-utils": "^1.8.0",
-        "@walletconnect/encoding": "^1.0.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.3",
-        "@walletconnect/types": "^1.8.0",
-        "bn.js": "4.11.8",
-        "js-sha3": "0.8.0",
-        "query-string": "6.13.5"
+        "@stablelib/chacha20poly1305": "1.0.1",
+        "@stablelib/hkdf": "1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha256": "1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "^3.1.0"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        "query-string": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+          "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+          "requires": {
+            "decode-uri-component": "^0.2.2",
+            "filter-obj": "^1.1.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        },
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
         }
       }
     },
     "@walletconnect/window-getters": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.0.tgz",
-      "integrity": "sha512-xB0SQsLaleIYIkSsl43vm8EwETpBzJ2gnzk7e0wMF3ktqiTGS6TFHxcprMl5R44KKh4tCcHCJwolMCaDSwtAaA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "requires": {
+        "tslib": "1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
     },
     "@walletconnect/window-metadata": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.0.tgz",
-      "integrity": "sha512-9eFvmJxIKCC3YWOL97SgRkKhlyGXkrHwamfechmqszbypFspaSk+t2jQXAEU7YClHF6Qjw5eYOmy1//zFi9/GA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
       "requires": {
-        "@walletconnect/window-getters": "^1.0.0"
+        "@walletconnect/window-getters": "^1.0.1",
+        "tslib": "1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@webassemblyjs/ast": {
@@ -38291,6 +39081,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "attr-accept": {
       "version": "2.2.2",
@@ -39062,25 +39857,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
-    },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -40093,9 +40869,9 @@
       "version": "10.4.0"
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -40216,9 +40992,9 @@
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
     "detect-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
-      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -40439,6 +41215,17 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -40478,14 +41265,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-    },
-    "eip1193-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "requires": {
-        "@json-rpc-tools/provider": "^1.5.5"
-      }
     },
     "ejs": {
       "version": "3.1.8",
@@ -41909,6 +42688,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "fast-redact": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ=="
+    },
     "fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -42065,6 +42849,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -45046,6 +45835,34 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "lit": {
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.6.tgz",
+      "integrity": "sha512-1amFHA7t4VaaDe+vdQejSVBklwtH9svGoG6/dZi9JhxtJBBlqY5D1RV7iLUYY0trCqQc4NfhYYZilZiVHt7Hxg==",
+      "requires": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.7.0"
+      }
+    },
+    "lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "requires": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -45105,6 +45922,11 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -45550,6 +46372,34 @@
         }
       }
     },
+    "motion": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
+      "integrity": "sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==",
+      "requires": {
+        "@motionone/animation": "^10.15.1",
+        "@motionone/dom": "^10.16.2",
+        "@motionone/svelte": "^10.16.2",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "@motionone/vue": "^10.16.2"
+      },
+      "dependencies": {
+        "@motionone/dom": {
+          "version": "10.16.2",
+          "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.16.2.tgz",
+          "integrity": "sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==",
+          "requires": {
+            "@motionone/animation": "^10.15.1",
+            "@motionone/generators": "^10.15.1",
+            "@motionone/types": "^10.15.1",
+            "@motionone/utils": "^10.15.1",
+            "hey-listen": "^1.0.8",
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -45974,6 +46824,11 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
+    "on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+    },
     "on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -46328,6 +47183,38 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="
+    },
+    "pino": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.15.1"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "pirates": {
       "version": "4.0.5",
@@ -47028,9 +47915,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "preact": {
-      "version": "10.11.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
-      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="
+      "version": "10.17.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.1.tgz",
+      "integrity": "sha512-X9BODrvQ4Ekwv9GURm9AKAGaomqXmip7NQTZgY7gcNmr7XE83adOMJvd3N42id1tMFU7ojiynRsYnY6/BRFxLA=="
     },
     "precond": {
       "version": "0.2.3",
@@ -47113,6 +48000,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
     "promise": {
       "version": "8.1.0",
@@ -47201,6 +48093,11 @@
         }
       }
     },
+    "proxy-compare": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.5.1.tgz",
+      "integrity": "sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA=="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -47244,9 +48141,9 @@
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
     },
     "qrcode": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.1.tgz",
-      "integrity": "sha512-nS8NJ1Z3md8uTjKtP+SGGhfqmTCs5flU/xR623oI0JX+Wepz9R8UrRVCTBTJm3qGw3rH6jJ6MUHjkDx15cxSSg==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
       "requires": {
         "dijkstrajs": "^1.0.1",
         "encode-utf8": "^1.0.3",
@@ -47261,11 +48158,12 @@
       }
     },
     "query-string": {
-      "version": "6.13.5",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
-      "integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }
@@ -47287,6 +48185,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "quick-lru": {
       "version": "5.1.1",
@@ -47845,6 +48748,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
+    },
     "receptacle": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
@@ -48276,6 +49184,11 @@
       "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
       "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
     },
+    "safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -48668,6 +49581,14 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "sonic-boom": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -48773,6 +49694,11 @@
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
       "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
     },
+    "split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+    },
     "sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
@@ -48863,6 +49789,11 @@
         "readable-stream": "^3.6.0",
         "xtend": "^4.0.2"
       }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "stream-transform": {
       "version": "3.2.0",
@@ -49371,6 +50302,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+    },
+    "thread-stream": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "requires": {
+        "real-require": "^0.1.0"
+      }
     },
     "throat": {
       "version": "6.0.1",
@@ -49958,6 +50897,15 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "valtio": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.11.0.tgz",
+      "integrity": "sha512-65Yd0yU5qs86b5lN1eu/nzcTgQ9/6YnD6iO+DDaDbQLn1Zv2w12Gwk43WkPlUBxk5wL/6cD5YMFf7kj6HZ1Kpg==",
+      "requires": {
+        "proxy-compare": "2.5.1",
+        "use-sync-external-store": "1.2.0"
+      }
+    },
     "varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
@@ -50032,18 +50980,23 @@
       }
     },
     "wagmi": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.9.5.tgz",
-      "integrity": "sha512-vmweVRVk3iKz0G5aCN5qW4H1OeFgP3h7YJqny/dTXZnnPl1pYHJHukl/gq7WwoDAQYI25PxwCmxy3sbIYKLTNA==",
+      "version": "0.12.19",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.12.19.tgz",
+      "integrity": "sha512-S/el9BDb/HNeQWh1v8TvntMPX/CgKLDAoJqDb8i7jifLfWPqFL7gor3vnI1Vs6ZlB8uh7m+K1Qyg+mKhbITuDQ==",
       "requires": {
-        "@coinbase/wallet-sdk": "^3.6.0",
-        "@tanstack/query-sync-storage-persister": "^4.14.5",
-        "@tanstack/react-query": "^4.14.5",
-        "@tanstack/react-query-persist-client": "^4.14.5",
-        "@wagmi/core": "0.8.5",
-        "@walletconnect/ethereum-provider": "^1.8.0",
-        "abitype": "^0.2.5",
+        "@tanstack/query-sync-storage-persister": "^4.27.1",
+        "@tanstack/react-query": "^4.28.0",
+        "@tanstack/react-query-persist-client": "^4.28.0",
+        "@wagmi/core": "0.10.17",
+        "abitype": "^0.3.0",
         "use-sync-external-store": "^1.2.0"
+      },
+      "dependencies": {
+        "abitype": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.3.0.tgz",
+          "integrity": "sha512-0YokyAV4hKMcy97Pl+6QgZBlBdZJN2llslOs7kiFY+cu7kMlVXDBpxMExfv0krzBCQt2t7hNovpQ3y/zvEm18A=="
+        }
       }
     },
     "walker": {
@@ -50918,9 +51871,9 @@
       }
     },
     "zustand": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.1.5.tgz",
-      "integrity": "sha512-PsdRT8Bvq22Yyh1tvpgdHNE7OAeFKqJXUxtJvj1Ixw2B9O2YZ1M34ImQ+xyZah4wZrR4lENMoDUutKPpyXCQ/Q==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
+      "integrity": "sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==",
       "requires": {
         "use-sync-external-store": "1.2.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28641,8 +28641,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "license": "Apache-2.0",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -50608,7 +50609,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4"
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "u3": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@rainbow-me/rainbowkit": "^0.12.18",
     "@react-pdf/renderer": "^3.0.0",
     "@sarcophagus-org/sarcophagus-v2-contracts": "^0.17.2",
-    "@sarcophagus-org/sarcophagus-v2-sdk-client": "0.2.16",
+    "@sarcophagus-org/sarcophagus-v2-sdk-client": "0.2.17",
     "@sentry/react": "^7.43.0",
     "@sentry/tracing": "^7.43.0",
     "@wagmi/chains": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "shamirs-secret-sharing-ts": "^1.0.2",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
-    "typescript": "^4.7.3",
+    "typescript": "^4.9.4",
     "url": "^0.11.0",
     "wagmi": "^0.12.19",
     "web-vitals": "^2.1.4"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@libp2p/webrtc-star": "^5.0.3",
     "@libp2p/websockets": "^5.0.1",
     "@multiformats/multiaddr": "^10.0.3",
-    "@rainbow-me/rainbowkit": "0.8.1",
+    "@rainbow-me/rainbowkit": "^0.12.18",
     "@react-pdf/renderer": "^3.0.0",
     "@sarcophagus-org/sarcophagus-v2-contracts": "^0.17.2",
     "@sarcophagus-org/sarcophagus-v2-sdk-client": "^0.2.8",
@@ -80,7 +80,7 @@
     "stream-http": "^3.2.0",
     "typescript": "^4.7.3",
     "url": "^0.11.0",
-    "wagmi": "^0.9.5",
+    "wagmi": "^0.12.19",
     "web-vitals": "^2.1.4"
   },
   "resolutions": {

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadFileAndKeyShares.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useUploadFileAndKeyShares.ts
@@ -37,7 +37,7 @@ export function useUploadFileAndKeyShares() {
           const { publicKey } = await response.json();
           await sarco.setSponsoredBundlr(publicKey, `${networkConfig.apiUrlBase}/bundlr/signData`);
         }
-        
+
         const uploadPromise = sarco.api.uploadFileToArweave({
           file: file!,
           archaeologistPublicKeys: Array.from(archaeologistPublicKeys.values()),

--- a/src/hooks/sarcoToken/useSarcoBalance.ts
+++ b/src/hooks/sarcoToken/useSarcoBalance.ts
@@ -8,7 +8,7 @@ export function useSarcoBalance() {
   const { address } = useAccount();
   const networkConfig = useNetworkConfig();
   const { data, isError, isLoading } = useContractRead({
-    address: networkConfig.sarcoTokenAddress,
+    address: networkConfig.sarcoTokenAddress as `0x${string}`,
     abi: SarcoTokenMock__factory.abi,
     functionName: 'balanceOf',
     args: [address],

--- a/src/hooks/thirdPartyFacet/useAccuse.ts
+++ b/src/hooks/thirdPartyFacet/useAccuse.ts
@@ -1,6 +1,5 @@
 import { useToast } from '@chakra-ui/react';
 import { ThirdPartyFacet__factory } from '@sarcophagus-org/sarcophagus-v2-contracts';
-import { Abi } from 'abitype';
 import { Signature } from 'ethers';
 import { isAddress } from 'ethers/lib/utils';
 import { useNetworkConfig } from 'lib/config';
@@ -26,8 +25,8 @@ export function useAccuse(
   const signaturesVrs = signatures.map(sig => ({ v: sig.v, r: sig.r, s: sig.s }));
 
   const { config, isError: mayFail } = usePrepareContractWrite({
-    address: networkConfig.diamondDeployAddress,
-    abi: ThirdPartyFacet__factory.abi as Abi,
+    address: networkConfig.diamondDeployAddress as `0x${string}`,
+    abi: ThirdPartyFacet__factory.abi,
     functionName: 'accuse',
     enabled,
     args: [sarcoId, publicKeys, signaturesVrs, paymentAddress],
@@ -41,6 +40,7 @@ export function useAccuse(
     onError() {
       setIsAccusing(false);
     },
+    mode: 'prepared',
   });
 
   function accuse() {

--- a/src/hooks/thirdPartyFacet/useCleanSarcophagus.ts
+++ b/src/hooks/thirdPartyFacet/useCleanSarcophagus.ts
@@ -1,6 +1,5 @@
 import { useToast } from '@chakra-ui/react';
 import { ThirdPartyFacet__factory } from '@sarcophagus-org/sarcophagus-v2-contracts';
-import { Abi } from 'abitype';
 import { useNetworkConfig } from 'lib/config';
 import { cleanFailure, cleanSuccess } from 'lib/utils/toast';
 import { useContractWrite, usePrepareContractWrite, useWaitForTransaction } from 'wagmi';
@@ -10,8 +9,8 @@ export function useCleanSarcophagus(sarcoId: string, canEmbalmerClean: boolean) 
   const toast = useToast();
 
   const { config, isError: mayFail } = usePrepareContractWrite({
-    address: networkConfig.diamondDeployAddress,
-    abi: ThirdPartyFacet__factory.abi as Abi,
+    address: networkConfig.diamondDeployAddress as `0x${string}`,
+    abi: ThirdPartyFacet__factory.abi,
     enabled: canEmbalmerClean,
     functionName: 'clean',
     args: [sarcoId],

--- a/src/hooks/useSubmitTransaction.ts
+++ b/src/hooks/useSubmitTransaction.ts
@@ -33,7 +33,7 @@ export function useSubmitTransaction(
   const addRecentTransaction = useAddRecentTransaction();
 
   const { config, error } = usePrepareContractWrite({
-    address: (address ?? networkConfig.diamondDeployAddress)  as `0x${string}`,
+    address: (address ?? networkConfig.diamondDeployAddress) as `0x${string}`,
     ...contractConfig.contractConfigParams,
   });
 

--- a/src/hooks/useSubmitTransaction.ts
+++ b/src/hooks/useSubmitTransaction.ts
@@ -3,13 +3,12 @@ import { useAddRecentTransaction } from '@rainbow-me/rainbowkit';
 import { useContractWrite, usePrepareContractWrite, useWaitForTransaction } from 'wagmi';
 import { formatToastMessage } from 'lib/utils/helpers';
 import { useNetworkConfig } from 'lib/config';
-import { Abi } from 'abitype';
 import { ethers } from 'ethers';
 import { useState } from 'react';
 
 interface ContractConfigParams {
-  address?: string;
-  abi: Abi;
+  address?: `0x${string}`;
+  abi: any;
   functionName: string;
   args: (string | ethers.BigNumber)[];
   mode: string;
@@ -34,7 +33,7 @@ export function useSubmitTransaction(
   const addRecentTransaction = useAddRecentTransaction();
 
   const { config, error } = usePrepareContractWrite({
-    address: address ?? networkConfig.diamondDeployAddress,
+    address: (address ?? networkConfig.diamondDeployAddress)  as `0x${string}`,
     ...contractConfig.contractConfigParams,
   });
 
@@ -63,6 +62,7 @@ export function useSubmitTransaction(
       });
     },
     ...config,
+    mode: 'prepared',
   });
 
   useWaitForTransaction({

--- a/src/hooks/viewStateFacet/useGetAvailableRewards.ts
+++ b/src/hooks/viewStateFacet/useGetAvailableRewards.ts
@@ -6,7 +6,7 @@ export function useGetAvailableRewards({ archaeologist }: { archaeologist: strin
   const networkConfig = useNetworkConfig();
 
   const { data } = useContractRead({
-    address: networkConfig.diamondDeployAddress,
+    address: networkConfig.diamondDeployAddress as `0x${string}`,
     abi: ViewStateFacet__factory.abi,
     functionName: 'getAvailableRewards',
     args: [archaeologist],

--- a/src/hooks/viewStateFacet/useGetCursedBond.ts
+++ b/src/hooks/viewStateFacet/useGetCursedBond.ts
@@ -6,7 +6,7 @@ export function useGetCursedBond({ archaeologist }: { archaeologist: string }) {
   const networkConfig = useNetworkConfig();
 
   const { data } = useContractRead({
-    address: networkConfig.diamondDeployAddress,
+    address: networkConfig.diamondDeployAddress as `0x${string}`,
     abi: ViewStateFacet__factory.abi,
     functionName: 'getCursedBond',
     args: [archaeologist],

--- a/src/hooks/viewStateFacet/useGetEmbalmerCanClean.ts
+++ b/src/hooks/viewStateFacet/useGetEmbalmerCanClean.ts
@@ -16,7 +16,7 @@ export function useGetEmbalmerCanClean(sarcophagus: SarcophagusData | undefined)
   const { timestampMs } = useSelector(x => x.appState);
 
   const { data } = useContractRead({
-    address: networkConfig.diamondDeployAddress,
+    address: networkConfig.diamondDeployAddress as `0x${string}`,
     abi: ViewStateFacet__factory.abi,
     functionName: 'getEmbalmerClaimWindow',
   });

--- a/src/hooks/viewStateFacet/useGetFreeBond.ts
+++ b/src/hooks/viewStateFacet/useGetFreeBond.ts
@@ -6,7 +6,7 @@ export function useGetFreeBond({ archaeologist }: { archaeologist: string }) {
   const networkConfig = useNetworkConfig();
 
   const { data } = useContractRead({
-    address: networkConfig.diamondDeployAddress,
+    address: networkConfig.diamondDeployAddress as `0x${string}`,
     abi: ViewStateFacet__factory.abi,
     functionName: 'getFreeBond',
     args: [archaeologist],

--- a/src/hooks/viewStateFacet/useGetGracePeriod.ts
+++ b/src/hooks/viewStateFacet/useGetGracePeriod.ts
@@ -6,7 +6,7 @@ export function useGetGracePeriod(): number {
   const networkConfig = useNetworkConfig();
 
   const { data } = useContractRead({
-    address: networkConfig.diamondDeployAddress,
+    address: networkConfig.diamondDeployAddress as `0x${string}`,
     abi: ViewStateFacet__factory.abi,
     functionName: 'getGracePeriod',
   });

--- a/src/hooks/viewStateFacet/useGetProtocolFeeBasePercentage.ts
+++ b/src/hooks/viewStateFacet/useGetProtocolFeeBasePercentage.ts
@@ -6,7 +6,7 @@ export function useGetProtocolFeeBasePercentage(): number {
   const networkConfig = useNetworkConfig();
 
   const { data } = useContractRead({
-    address: networkConfig.diamondDeployAddress,
+    address: networkConfig.diamondDeployAddress as `0x${string}`,
     abi: ViewStateFacet__factory.abi,
     functionName: 'getProtocolFeeBasePercentage',
   });

--- a/src/hooks/viewStateFacet/useGetSarcophagusArchaeologist.ts
+++ b/src/hooks/viewStateFacet/useGetSarcophagusArchaeologist.ts
@@ -12,7 +12,7 @@ export function useGetSarcophagusArchaeologist({
   const networkConfig = useNetworkConfig();
 
   const { data } = useContractRead({
-    address: networkConfig.diamondDeployAddress,
+    address: networkConfig.diamondDeployAddress as `0x${string}`,
     abi: ViewStateFacet__factory.abi,
     functionName: 'getSarcophagusArchaeologist',
     args: [sarcoId, archaeologist],

--- a/src/hooks/viewStateFacet/useGetSarcophagusArchaeologists.ts
+++ b/src/hooks/viewStateFacet/useGetSarcophagusArchaeologists.ts
@@ -11,7 +11,7 @@ export function useGetSarcophagusArchaeologists(
 
   const { data } = useContractReads({
     contracts: archaeologistAddresses.map(address => ({
-      address: networkConfig.diamondDeployAddress,
+      address: networkConfig.diamondDeployAddress as `0x${string}`,
       abi: ViewStateFacet__factory.abi,
       functionName: 'getSarcophagusArchaeologist',
       args: [sarcoId, address],

--- a/src/lib/config/NetworkConfigProvider.tsx
+++ b/src/lib/config/NetworkConfigProvider.tsx
@@ -9,6 +9,8 @@ import { sarco } from '@sarcophagus-org/sarcophagus-v2-sdk-client';
 export function NetworkConfigProvider({ children }: { children: React.ReactNode }) {
   const { chain } = useNetwork();
 
+  const [currentChainId, setCurrentChainId] = useState<number | undefined>();
+  const [isInitialisingSarcoSdk, setIsInitialisingSarcoSdk] = useState(false);
   const [isSdkInitialized, setIsSdkInitialized] = useState(false);
   const [isBundlrConnected, setIsBundlrConnected] = useState(false);
 
@@ -16,22 +18,47 @@ export function NetworkConfigProvider({ children }: { children: React.ReactNode 
     const validChain = !!chain && !!networkConfigs[chain.id];
     const config = validChain ? networkConfigs[chain.id] : emptyConfig;
 
+    if (isInitialisingSarcoSdk) return config;
+
+    const initSarcoSdk = (chainId: number) => sarco
+            .init({
+              chainId: chainId,
+              etherscanApiKey: config.etherscanApiKey,
+              zeroExApiKey: process.env.REACT_APP_ZERO_EX_API_KEY,
+            })
+            .then(() => {
+              setCurrentChainId(chain?.id);
+              setIsInitialisingSarcoSdk(false);
+              setIsSdkInitialized(true);
+            });
+
+    const chainChanged = chain?.id !== currentChainId;
+    if (chainChanged) {
+      setIsInitialisingSarcoSdk(true);
+      setIsSdkInitialized(false);
+
+      new Promise<void>(res => setTimeout(() => res(), 10)).then(() => {
+        if (validChain) {
+          initSarcoSdk(chain.id);
+        } else {
+          setCurrentChainId(chain?.id);
+          setIsInitialisingSarcoSdk(false);
+        }
+      });
+    }
+
     if (validChain && !isSdkInitialized) {
-      sarco
-        .init({
-          chainId: chain.id,
-          etherscanApiKey: config.etherscanApiKey,
-          zeroExApiKey: process.env.REACT_APP_ZERO_EX_API_KEY,
-        })
-        .then(() => setIsSdkInitialized(true));
+      setIsInitialisingSarcoSdk(true);
+      initSarcoSdk(chain.id);
     }
 
     return sarco.isInitialised ? config : emptyConfig;
-  }, [chain, isSdkInitialized]);
+  }, [chain, currentChainId, isSdkInitialized, isInitialisingSarcoSdk]);
 
   const supportedChainIds =
     process.env.REACT_APP_SUPPORTED_CHAIN_IDS?.split(',').map(id => parseInt(id)) || [];
 
+  // todo: verify this actually updates
   const isSupportedChain = supportedChainIds.includes(networkConfig.chainId);
 
   const supportedNetworkNames = Object.values(networkConfigs)
@@ -42,6 +69,7 @@ export function NetworkConfigProvider({ children }: { children: React.ReactNode 
     <NetworkConfigContext.Provider value={networkConfig}>
       <SupportedNetworkContext.Provider
         value={{
+          isInitialisingSarcoSdk: isInitialisingSarcoSdk,
           isSarcoInitialized: isSdkInitialized,
           isBundlrConnected,
           setIsBundlrConnected,

--- a/src/lib/config/NetworkConfigProvider.tsx
+++ b/src/lib/config/NetworkConfigProvider.tsx
@@ -32,7 +32,7 @@ export function NetworkConfigProvider({ children }: { children: React.ReactNode 
   const supportedChainIds =
     process.env.REACT_APP_SUPPORTED_CHAIN_IDS?.split(',').map(id => parseInt(id)) || [];
 
-  const isSupportedChain = supportedChainIds.includes(networkConfig.chainId ?? 0);
+  const isSupportedChain = supportedChainIds.includes(networkConfig.chainId);
 
   const supportedNetworkNames = Object.values(networkConfigs)
     .filter(config => supportedChainIds.includes(config.chainId))

--- a/src/lib/config/NetworkConfigProvider.tsx
+++ b/src/lib/config/NetworkConfigProvider.tsx
@@ -20,17 +20,18 @@ export function NetworkConfigProvider({ children }: { children: React.ReactNode 
 
     if (isInitialisingSarcoSdk) return config;
 
-    const initSarcoSdk = (chainId: number) => sarco
-            .init({
-              chainId: chainId,
-              etherscanApiKey: config.etherscanApiKey,
-              zeroExApiKey: process.env.REACT_APP_ZERO_EX_API_KEY,
-            })
-            .then(() => {
-              setCurrentChainId(chain?.id);
-              setIsInitialisingSarcoSdk(false);
-              setIsSdkInitialized(true);
-            });
+    const initSarcoSdk = (chainId: number) =>
+      sarco
+        .init({
+          chainId: chainId,
+          etherscanApiKey: config.etherscanApiKey,
+          zeroExApiKey: process.env.REACT_APP_ZERO_EX_API_KEY,
+        })
+        .then(() => {
+          setCurrentChainId(chain?.id);
+          setIsInitialisingSarcoSdk(false);
+          setIsSdkInitialized(true);
+        });
 
     const chainChanged = chain?.id !== currentChainId;
     if (chainChanged) {
@@ -58,7 +59,6 @@ export function NetworkConfigProvider({ children }: { children: React.ReactNode 
   const supportedChainIds =
     process.env.REACT_APP_SUPPORTED_CHAIN_IDS?.split(',').map(id => parseInt(id)) || [];
 
-  // todo: verify this actually updates
   const isSupportedChain = supportedChainIds.includes(networkConfig.chainId);
 
   const supportedNetworkNames = Object.values(networkConfigs)

--- a/src/lib/config/NetworkConfigProvider.tsx
+++ b/src/lib/config/NetworkConfigProvider.tsx
@@ -53,7 +53,7 @@ export function NetworkConfigProvider({ children }: { children: React.ReactNode 
       initSarcoSdk(chain.id);
     }
 
-    return sarco.isInitialised ? config : emptyConfig;
+    return sarco.isInitialised && validChain ? config : emptyConfig;
   }, [chain, currentChainId, isSdkInitialized, isInitialisingSarcoSdk]);
 
   const supportedChainIds =

--- a/src/lib/config/useSupportedNetwork.ts
+++ b/src/lib/config/useSupportedNetwork.ts
@@ -10,7 +10,7 @@ interface SupportedNetwork {
 
 export const SupportedNetworkContext = createContext<SupportedNetwork>({} as SupportedNetwork);
 
-// TODO: Rename to something more appropriate
+// TODO: Rename to something more appropriate. `useNetworkInfo`?
 export function useSupportedNetwork(): SupportedNetwork {
   return useContext(SupportedNetworkContext);
 }

--- a/src/lib/config/useSupportedNetwork.ts
+++ b/src/lib/config/useSupportedNetwork.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react';
 
 interface SupportedNetwork {
   isSupportedChain: boolean;
+  isInitialisingSarcoSdk: boolean;
   isSarcoInitialized: boolean;
   isBundlrConnected: boolean;
   setIsBundlrConnected: Function;

--- a/src/lib/network/WalletProvider.tsx
+++ b/src/lib/network/WalletProvider.tsx
@@ -17,7 +17,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 
   const { connectors } = getDefaultWallets({
     appName: 'Sarcophagus v2',
-    projectId: 'update-me', // TODO: Update this
+    projectId: '82c7fb000145342f2d1b57dc2d83d001', // TODO: Update this
     chains,
   });
 

--- a/src/lib/network/WalletProvider.tsx
+++ b/src/lib/network/WalletProvider.tsx
@@ -4,7 +4,7 @@ import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { publicProvider } from 'wagmi/providers/public';
 import { infuraProvider } from 'wagmi/providers/infura';
 import { walletConnectionTheme } from '../../theme/walletConnectionTheme';
-import { sepolia, mainnet, goerli, hardhat } from '@wagmi/chains';
+import { sepolia, mainnet, goerli, hardhat } from '@wagmi/core/chains';
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
   const { chains, provider } = configureChains(
@@ -17,6 +17,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 
   const { connectors } = getDefaultWallets({
     appName: 'Sarcophagus v2',
+    projectId: 'update-me', // TODO: Update this
     chains,
   });
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Link, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Button, Center, Flex, Link, Spinner, Text, Tooltip } from '@chakra-ui/react';
 import { ConnectWalletButton } from 'components/ConnectWalletButton';
 import { useAccount } from 'wagmi';
 import { Navigate, NavLink, Route, Routes, BrowserRouter as Router } from 'react-router-dom';
@@ -142,7 +142,7 @@ export function Pages() {
   // Globally stores the timestamp from the latest block
   useTimestampMs();
 
-  const { isSupportedChain, isSarcoInitialized } = useSupportedNetwork();
+  const { isSupportedChain, isSarcoInitialized, isInitialisingSarcoSdk } = useSupportedNetwork();
   const currentCommitHash = process.env.REACT_APP_COMMIT_REF;
 
   return (
@@ -232,7 +232,16 @@ export function Pages() {
             </Routes>
           ) : (
             <CreateSarcophagusContextProvider>
-              <WalletDisconnectPage />
+              {isInitialisingSarcoSdk ? (
+                <Center
+                  height="100%"
+                  width="100%"
+                >
+                  <Spinner size="xl" />
+                </Center>
+              ) : (
+                <WalletDisconnectPage />
+              )}
             </CreateSarcophagusContextProvider>
           )}
         </Flex>


### PR DESCRIPTION
This PR fixes a number of inconsistencies that occur when switching networks from an already connected state.

The wagmi library had to be updated as part of this fix. 
With this update, WalletConnect (v2) is now working again and has been restored as an option when connecting to the dapp.

NOTE:
`projectId` in `src/lib/network/WalletProvider.tsx:20` will need to be updated to use one that the DAO controls.

It is currently completely free to create one [on the wallet connect dashboard](https://cloud.walletconnect.com/app), and leaving it as it shouldn't lead to any issues in the near term, so not an urgent thing to do.