### PR TITLE
Fix create sarco steps order

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ cp .env.example .env
 
 - after creating a .env file, you’ll need to set `REACT_APP_INFURA_API_KEY` to an Infura API key that you own
 
-## Running on Goerli with MetaMask
+## Running on an Ethereum testnet with MetaMask
 
-You’ll need an address on Goerli funded with ETH and SARCO to run through the full create sarcophagus flow.
+You’ll need an address on the testnet funded with ETH and SARCO to run through the full create sarcophagus flow.
 
 1. Install metamask or other supported wallet
 2. On the network dropdown at the top of the MetaMask popup, select show/hide test networks and toggle on test networks
-3. Change your network to Goerli
-4. Import the private key for an account funded with Goerli Ether and SARCO
+3. Change your network to the testnet
+4. Import the private key for an account funded with Testnet Ether and SARCO
 5. On step 3 within the embalm flow, you’ll be prompted to fund your Bundlr account with Ether. This process can take up
-   to 20 minutes to complete on Goerli.
+   to 20 minutes to complete on testnets.
 
 ## Running on hardhat local network and ArLocal with MetaMask
 

--- a/src/features/embalm/stepContent/components/ProgressTracker.tsx
+++ b/src/features/embalm/stepContent/components/ProgressTracker.tsx
@@ -18,7 +18,6 @@ export function ProgressTracker({
   currentStage,
   stageError,
   retryStage,
-  isApproved,
   children,
 }: ProgressTrackerProps) {
   // Determine the current stage status using the stage of a child and the current stage passed on a
@@ -39,11 +38,7 @@ export function ProgressTracker({
     if (React.isValidElement(child)) {
       return React.cloneElement<ProgressTrackerStageProps>(child, {
         // index is a number but is being used as a value of the CreateSarcophagusStage enum
-        stageStatus: getStageStatus(
-          currentStage === CreateSarcophagusStage.SUBMIT_SARCOPHAGUS && isApproved
-            ? index + 2
-            : index + 1
-        ),
+        stageStatus: getStageStatus(child.props.stageIndex),
         index,
         stageError,
         retryStage,

--- a/src/features/embalm/stepContent/components/ProgressTrackerStage.tsx
+++ b/src/features/embalm/stepContent/components/ProgressTrackerStage.tsx
@@ -12,6 +12,7 @@ export enum StageStatus {
 export interface ProgressTrackerStageProps {
   stageStatus?: StageStatus;
   index?: number;
+  stageIndex: number;
   stageError?: string | undefined;
   retryStage?: () => void;
   children: React.ReactNode;

--- a/src/features/embalm/stepContent/hooks/useBundlrSession.ts
+++ b/src/features/embalm/stepContent/hooks/useBundlrSession.ts
@@ -50,7 +50,7 @@ export function useBundlrSession() {
   const connectToBundlr = useCallback(async (): Promise<void> => {
     if (isHardhatNetwork) {
       console.error(
-        'Bundlr cannot be used with the hardhat local network. Switch to Goerli or Mainnet to interact with bunldr.'
+        'Bundlr cannot be used with the hardhat local network. Switch to Sepolia or Mainnet to interact with bunldr.'
       );
       return;
     }

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useCreateSarcophagus.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useCreateSarcophagus.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ethers } from 'ethers';
+import { BigNumber } from 'ethers';
 import { useArchaeologistSignatureNegotiation } from 'features/embalm/stepContent/hooks/useCreateSarcophagus/useArchaeologistSignatureNegotiation';
 import { useApprove } from 'hooks/sarcoToken/useApprove';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -26,7 +26,6 @@ export class CancelCreateToken {
 
 export function useCreateSarcophagus(
   createSarcophagusStages: Record<number, string>,
-  embalmerFacet: ethers.Contract,
   approveAmount: BigNumber
 ) {
   const dispatch = useDispatch();
@@ -69,8 +68,8 @@ export function useCreateSarcophagus(
     return new Map<CreateSarcophagusStage, (...args: any[]) => Promise<any>>([
       [CreateSarcophagusStage.DIAL_ARCHAEOLOGISTS, dialSelectedArchaeologists],
       [CreateSarcophagusStage.ARCHAEOLOGIST_NEGOTIATION, initiateSarcophagusNegotiation],
-      [CreateSarcophagusStage.UPLOAD_PAYLOAD, uploadAndSetArweavePayload],
       [CreateSarcophagusStage.BUY_SARCO, buySarco],
+      [CreateSarcophagusStage.UPLOAD_PAYLOAD, uploadAndSetArweavePayload],
       [CreateSarcophagusStage.APPROVE, approveSarcoToken],
       [CreateSarcophagusStage.SUBMIT_SARCOPHAGUS, submitSarcophagus],
       [CreateSarcophagusStage.CLEAR_STATE, clearSarcophagusState],

--- a/src/features/embalm/stepContent/utils/errors.ts
+++ b/src/features/embalm/stepContent/utils/errors.ts
@@ -16,6 +16,7 @@ const processArchCommsException = (offendingArchs: ArchaeologistData[]) => {
 export const createSarcophagusErrors: Record<number, string> = {
   [CreateSarcophagusStage.DIAL_ARCHAEOLOGISTS]: 'Failure Connecting to All Selected Archaeologists',
   [CreateSarcophagusStage.ARCHAEOLOGIST_NEGOTIATION]: 'Retrieving Archaeologist Signatures Failed',
+  [CreateSarcophagusStage.BUY_SARCO]: 'Failed to swap ETH for SARCO',
   [CreateSarcophagusStage.UPLOAD_PAYLOAD]: 'Upload File Data to Arweave Failed',
   [CreateSarcophagusStage.APPROVE]: 'Approval Failed',
   [CreateSarcophagusStage.SUBMIT_SARCOPHAGUS]: 'Create Sarcophagus Failed',


### PR DESCRIPTION
This PR fixes a bug that occurred after the gassless upload update causing the file upload step to prematurely show as complete.

The update required the `ProgressTracker` to use a `trueStageIndex` (computed and added in `CreateSarcophagus.tsx`) to determine what each stage's status is.

This means `isApproved` is no longer needed to check the status of the correct stage (index+1 or index+2 based on if approval step is included or not), and can directly use `child.props.stageIndex` instead. This needs to be properly tested.