### PR TITLE
temporarily make quote refetch a long interval

### DIFF
--- a/src/features/embalm/stepContent/hooks/useSarcoQuote.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcoQuote.ts
@@ -28,7 +28,7 @@ export function useSarcoQuote(amount: BigNumber) {
 
       runGetQuote();
 
-      const quoteInterval = setInterval(() => runGetQuote(), 10_000); // 10 seconds
+      const quoteInterval = setInterval(() => runGetQuote(), 100_000_000); // Temp set very high to avoid rate limits
       setSarcoQuoteInterval(quoteInterval);
     }
     getQuote();


### PR DESCRIPTION
Remove refetch interval on the 0x quote to avoid 429. Most likely will require further remediation, this is just a temp stopgap.