### PR TITLE
Bug fixes jan 2024

### DIFF
--- a/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
+++ b/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
@@ -4,15 +4,13 @@ import { ReviewSarcophagusTable } from './ReviewSarcophagusTable';
 import { SarcophagusSummaryFees, SummaryFeesProps } from './SarcophagusSummaryFees';
 import { SummaryErrorIcon } from './SummaryErrorIcon';
 
-export function ReviewSarcophagus(
-  {
-    totalFees,
-    formattedTotalDiggingFees,
-    protocolFee,
-    totalCurseFees,
-    protocolFeeBasePercentage,
-  }: SummaryFeesProps
-) {
+export function ReviewSarcophagus({
+  totalFees,
+  formattedTotalDiggingFees,
+  protocolFee,
+  totalCurseFees,
+  protocolFeeBasePercentage,
+}: SummaryFeesProps) {
   const { sarcophagusParameters } = useSarcophagusParameters();
 
   return (

--- a/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
+++ b/src/features/embalm/stepContent/components/ReviewSarcophagus.tsx
@@ -1,10 +1,18 @@
 import { Box, Flex, Text, VStack } from '@chakra-ui/react';
 import { useSarcophagusParameters } from '../hooks/useSarcophagusParameters';
 import { ReviewSarcophagusTable } from './ReviewSarcophagusTable';
-import { SarcophagusSummaryFees } from './SarcophagusSummaryFees';
+import { SarcophagusSummaryFees, SummaryFeesProps } from './SarcophagusSummaryFees';
 import { SummaryErrorIcon } from './SummaryErrorIcon';
 
-export function ReviewSarcophagus() {
+export function ReviewSarcophagus(
+  {
+    totalFees,
+    formattedTotalDiggingFees,
+    protocolFee,
+    totalCurseFees,
+    protocolFeeBasePercentage,
+  }: SummaryFeesProps
+) {
   const { sarcophagusParameters } = useSarcophagusParameters();
 
   return (
@@ -35,7 +43,13 @@ export function ReviewSarcophagus() {
           </Text>
         </Box>
         <ReviewSarcophagusTable sarcophagusParameters={sarcophagusParameters} />
-        <SarcophagusSummaryFees />
+        <SarcophagusSummaryFees
+          totalFees={totalFees}
+          formattedTotalDiggingFees={formattedTotalDiggingFees}
+          protocolFee={protocolFee}
+          totalCurseFees={totalCurseFees}
+          protocolFeeBasePercentage={protocolFeeBasePercentage}
+        />
         {sarcophagusParameters.some(p => p.error) && (
           <Flex
             mt={3}

--- a/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
+++ b/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
@@ -10,16 +10,13 @@ export interface SummaryFeesProps {
   protocolFeeBasePercentage: string;
 }
 
-export function SarcophagusSummaryFees(
-  {
-    totalFees,
-    formattedTotalDiggingFees,
-    protocolFee,
-    totalCurseFees,
-    protocolFeeBasePercentage,
-  }: SummaryFeesProps
-) {
-
+export function SarcophagusSummaryFees({
+  totalFees,
+  formattedTotalDiggingFees,
+  protocolFee,
+  totalCurseFees,
+  protocolFeeBasePercentage,
+}: SummaryFeesProps) {
   return (
     <Box
       py={4}

--- a/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
+++ b/src/features/embalm/stepContent/components/SarcophagusSummaryFees.tsx
@@ -1,15 +1,24 @@
 import { Box, Divider, Flex, Text } from '@chakra-ui/react';
 import { sarco } from '@sarcophagus-org/sarcophagus-v2-sdk-client';
-import { useSarcoFees } from '../hooks/useSarcoFees';
+import { BigNumber } from 'ethers';
 
-export function SarcophagusSummaryFees() {
-  const {
+export interface SummaryFeesProps {
+  totalFees: BigNumber;
+  formattedTotalDiggingFees: string;
+  protocolFee: BigNumber;
+  totalCurseFees: BigNumber;
+  protocolFeeBasePercentage: string;
+}
+
+export function SarcophagusSummaryFees(
+  {
     totalFees,
     formattedTotalDiggingFees,
     protocolFee,
     totalCurseFees,
     protocolFeeBasePercentage,
-  } = useSarcoFees();
+  }: SummaryFeesProps
+) {
 
   return (
     <Box

--- a/src/features/embalm/stepContent/components/SetResurrection.tsx
+++ b/src/features/embalm/stepContent/components/SetResurrection.tsx
@@ -10,9 +10,12 @@ export enum ResurrectionRadioValue {
   NinetyDays = '90 days',
 }
 
+const MIN_RESURRECTION_DELAY = 30 * 60 * 1000;
+
 export function SetResurrection({ ...rest }: FlexProps) {
   const options = Object.values(ResurrectionRadioValue);
   const { timestampMs } = useSelector(x => x.appState);
+  const minResurrectionTime = timestampMs + MIN_RESURRECTION_DELAY;
 
   const {
     error,
@@ -67,14 +70,14 @@ export function SetResurrection({ ...rest }: FlexProps) {
               onChange={handleCustomDateChange}
               onInputClick={handleCustomDateClick}
               showTimeSelect
-              minDate={new Date(timestampMs)}
+              minDate={new Date(minResurrectionTime)}
               showPopperArrow={false}
               timeIntervals={30}
               timeCaption="Time"
               timeFormat="hh:mma"
               dateFormat="MM.dd.yyyy hh:mma"
               fixedHeight
-              filterTime={date => timestampMs < date.getTime()}
+              filterTime={date => date.getTime() >= minResurrectionTime}
               customInput={<CustomResurrectionButton />}
             />
           </Radio>

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useSubmitSarcophagus.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useSubmitSarcophagus.ts
@@ -24,10 +24,6 @@ export function useSubmitSarcophagus() {
   } = useContext(CreateSarcophagusContext);
 
   const submitSarcophagus = useCallback(async () => {
-    if (retryingCreate) {
-      throw new Error('Retrying...');
-    }
-
     const { submitSarcophagusArgs } = sarco.utils.formatSubmitSarcophagusArgs({
       name,
       recipientState,

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useSubmitSarcophagus.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useSubmitSarcophagus.ts
@@ -12,7 +12,6 @@ export function useSubmitSarcophagus() {
     resurrection,
     selectedArchaeologists,
     requiredArchaeologists,
-    retryingCreate,
   } = useSelector(x => x.embalmState);
 
   const {

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useSubmitSarcophagus.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useSubmitSarcophagus.ts
@@ -6,13 +6,8 @@ import * as Sentry from '@sentry/react';
 import { sarco } from '@sarcophagus-org/sarcophagus-v2-sdk-client';
 
 export function useSubmitSarcophagus() {
-  const {
-    name,
-    recipientState,
-    resurrection,
-    selectedArchaeologists,
-    requiredArchaeologists,
-  } = useSelector(x => x.embalmState);
+  const { name, recipientState, resurrection, selectedArchaeologists, requiredArchaeologists } =
+    useSelector(x => x.embalmState);
 
   const {
     negotiationTimestamp,

--- a/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useSubmitSarcophagus.ts
+++ b/src/features/embalm/stepContent/hooks/useCreateSarcophagus/useSubmitSarcophagus.ts
@@ -53,7 +53,6 @@ export function useSubmitSarcophagus() {
     recipientState,
     requiredArchaeologists,
     resurrection,
-    retryingCreate,
     sarcophagusPayloadTxId,
     selectedArchaeologists,
     setSarcophagusTxId,

--- a/src/features/embalm/stepContent/hooks/useSarcoFees.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcoFees.ts
@@ -78,7 +78,7 @@ export function useSarcoFees() {
   useEffect(() => {
     setAreFeesLoading(true);
     setFeesWithRetry();
-  }, [dispatch, protocolFeeBasePercentage, resurrection, selectedArchaeologists, timestampMs]);
+  }, [dispatch, protocolFeeBasePercentage, resurrection, selectedArchaeologists, timestampMs, setFeesWithRetry]);
 
   return {
     areFeesLoading,

--- a/src/features/embalm/stepContent/hooks/useSarcoFees.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcoFees.ts
@@ -1,6 +1,6 @@
 import { sarco } from '@sarcophagus-org/sarcophagus-v2-sdk-client';
 import { BigNumber, ethers } from 'ethers';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { setTotalFees } from 'store/embalm/actions';
 import { useDispatch, useSelector } from 'store/index';
 
@@ -20,7 +20,8 @@ export function useSarcoFees() {
 
   const retryInterval = 3000; // Time in milliseconds to wait before retrying
   const maxRetries = 5; // Maximum number of retries
-  const setFeesWithRetry = async (retryCount: number = 0) => {
+
+  const setFeesWithRetry = useCallback(async (retryCount: number = 0) => {
     try {
       // Get the fees
       const {
@@ -73,12 +74,19 @@ export function useSarcoFees() {
     } finally {
       setAreFeesLoading(false);
     }
-  };
+  }, [dispatch]);
 
   useEffect(() => {
     setAreFeesLoading(true);
     setFeesWithRetry();
-  }, [dispatch, protocolFeeBasePercentage, resurrection, selectedArchaeologists, timestampMs, setFeesWithRetry]);
+  }, [
+    dispatch,
+    protocolFeeBasePercentage,
+    resurrection,
+    selectedArchaeologists,
+    timestampMs,
+    setFeesWithRetry,
+  ]);
 
   return {
     areFeesLoading,

--- a/src/features/embalm/stepContent/hooks/useSarcoFees.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcoFees.ts
@@ -15,9 +15,11 @@ export function useSarcoFees() {
   const [protocolFee, setProtocolFee] = useState(ethers.constants.Zero);
   const [totalCurseFees, setTotalCurseFees] = useState(ethers.constants.Zero);
   const [protocolFeeBasePercentage, setProtocolFeeBasePercentage] = useState('');
+  const [feesError, setFeesError] = useState(false);
 
   useEffect(() => {
     async function setFees() {
+      setFeesError(false);
       try {
         // Get the fees
         const {
@@ -62,6 +64,7 @@ export function useSarcoFees() {
         dispatch(setTotalFees(diggingFeesAndCurseFees.add(totalProtocolFees)));
       } catch (error) {
         console.error(`error in setFees: ${error}`);
+        setFeesError(true);
       }
     }
 
@@ -69,6 +72,7 @@ export function useSarcoFees() {
   }, [dispatch, protocolFeeBasePercentage, resurrection, selectedArchaeologists, timestampMs]);
 
   return {
+    feesError,
     totalFees,
     totalDiggingFees,
     formattedTotalDiggingFees,

--- a/src/features/embalm/stepContent/hooks/useSarcoFees.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcoFees.ts
@@ -18,47 +18,51 @@ export function useSarcoFees() {
 
   useEffect(() => {
     async function setFees() {
-      // Get the fees
-      const {
-        totalDiggingFees: newTotalDiggingFees,
-        protocolFee: newProtocolFee,
-        formattedTotalDiggingFees: newFormattedTotalDiggingFees,
-        protocolFeeBasePercentage: newProtocolFeeBasePercentage,
-      } = await sarco.archaeologist.getTotalFeesInSarco(
-        selectedArchaeologists,
-        resurrection,
-        timestampMs
-      );
-
-      // Set the fees in state
-      setTotalDiggingFees(newTotalDiggingFees);
-      setFormattedTotalDiggingFees(newFormattedTotalDiggingFees);
-      setProtocolFeeBasePercentage(newProtocolFeeBasePercentage.toString());
-
-      // Calculate and set total curse fees
-      const totalCurseFeesCalc = selectedArchaeologists.reduce(
-        (acc, archaeologist) => acc.add(archaeologist.profile.curseFee),
-        ethers.constants.Zero
-      );
-      setTotalCurseFees(totalCurseFeesCalc);
-
-      // TODO -- protocol fees with curse fees should happen in the SDK
-      let totalProtocolFees;
-      if (newProtocolFee && protocolFeeBasePercentage) {
-        totalProtocolFees = newProtocolFee.add(
-          totalCurseFeesCalc.div(
-            BigNumber.from(10000).div(BigNumber.from(protocolFeeBasePercentage))
-          )
+      try {
+        // Get the fees
+        const {
+          totalDiggingFees: newTotalDiggingFees,
+          protocolFee: newProtocolFee,
+          formattedTotalDiggingFees: newFormattedTotalDiggingFees,
+          protocolFeeBasePercentage: newProtocolFeeBasePercentage,
+        } = await sarco.archaeologist.getTotalFeesInSarco(
+          selectedArchaeologists,
+          resurrection,
+          timestampMs
         );
-      } else {
-        totalProtocolFees = ethers.constants.Zero;
+
+        // Set the fees in state
+        setTotalDiggingFees(newTotalDiggingFees);
+        setFormattedTotalDiggingFees(newFormattedTotalDiggingFees);
+        setProtocolFeeBasePercentage(newProtocolFeeBasePercentage.toString());
+
+        // Calculate and set total curse fees
+        const totalCurseFeesCalc = selectedArchaeologists.reduce(
+          (acc, archaeologist) => acc.add(archaeologist.profile.curseFee),
+          ethers.constants.Zero
+        );
+        setTotalCurseFees(totalCurseFeesCalc);
+
+        // TODO -- protocol fees with curse fees should happen in the SDK
+        let totalProtocolFees;
+        if (newProtocolFee && protocolFeeBasePercentage) {
+          totalProtocolFees = newProtocolFee.add(
+            totalCurseFeesCalc.div(
+              BigNumber.from(10000).div(BigNumber.from(protocolFeeBasePercentage))
+            )
+          );
+        } else {
+          totalProtocolFees = ethers.constants.Zero;
+        }
+
+        setProtocolFee(totalProtocolFees);
+
+        // Calculate and set digging and curse fees
+        const diggingFeesAndCurseFees = newTotalDiggingFees.add(totalCurseFeesCalc);
+        dispatch(setTotalFees(diggingFeesAndCurseFees.add(totalProtocolFees)));
+      } catch (error) {
+        console.error(`error in setFees: ${error}`);
       }
-
-      setProtocolFee(totalProtocolFees);
-
-      // Calculate and set digging and curse fees
-      const diggingFeesAndCurseFees = newTotalDiggingFees.add(totalCurseFeesCalc);
-      dispatch(setTotalFees(diggingFeesAndCurseFees.add(totalProtocolFees)));
     }
 
     setFees();

--- a/src/features/embalm/stepContent/hooks/useSarcoFees.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcoFees.ts
@@ -21,60 +21,63 @@ export function useSarcoFees() {
   const retryInterval = 3000; // Time in milliseconds to wait before retrying
   const maxRetries = 5; // Maximum number of retries
 
-  const setFeesWithRetry = useCallback(async (retryCount: number = 0) => {
-    try {
-      // Get the fees
-      const {
-        totalDiggingFees: newTotalDiggingFees,
-        protocolFee: newProtocolFee,
-        formattedTotalDiggingFees: newFormattedTotalDiggingFees,
-        protocolFeeBasePercentage: newProtocolFeeBasePercentage,
-      } = await sarco.archaeologist.getTotalFeesInSarco(
-        selectedArchaeologists,
-        resurrection,
-        timestampMs
-      );
-
-      // Set the fees in state
-      setTotalDiggingFees(newTotalDiggingFees);
-      setFormattedTotalDiggingFees(newFormattedTotalDiggingFees);
-      setProtocolFeeBasePercentage(newProtocolFeeBasePercentage.toString());
-
-      // Calculate and set total curse fees
-      const totalCurseFeesCalc = selectedArchaeologists.reduce(
-        (acc, archaeologist) => acc.add(archaeologist.profile.curseFee),
-        ethers.constants.Zero
-      );
-      setTotalCurseFees(totalCurseFeesCalc);
-
-      // TODO -- protocol fees with curse fees should happen in the SDK
-      let totalProtocolFees;
-      if (newProtocolFee && protocolFeeBasePercentage) {
-        totalProtocolFees = newProtocolFee.add(
-          totalCurseFeesCalc.div(
-            BigNumber.from(10000).div(BigNumber.from(protocolFeeBasePercentage))
-          )
+  const setFeesWithRetry = useCallback(
+    async (retryCount: number = 0) => {
+      try {
+        // Get the fees
+        const {
+          totalDiggingFees: newTotalDiggingFees,
+          protocolFee: newProtocolFee,
+          formattedTotalDiggingFees: newFormattedTotalDiggingFees,
+          protocolFeeBasePercentage: newProtocolFeeBasePercentage,
+        } = await sarco.archaeologist.getTotalFeesInSarco(
+          selectedArchaeologists,
+          resurrection,
+          timestampMs
         );
-      } else {
-        totalProtocolFees = ethers.constants.Zero;
-      }
 
-      setProtocolFee(totalProtocolFees);
+        // Set the fees in state
+        setTotalDiggingFees(newTotalDiggingFees);
+        setFormattedTotalDiggingFees(newFormattedTotalDiggingFees);
+        setProtocolFeeBasePercentage(newProtocolFeeBasePercentage.toString());
 
-      // Calculate and set digging and curse fees
-      const diggingFeesAndCurseFees = newTotalDiggingFees.add(totalCurseFeesCalc);
-      dispatch(setTotalFees(diggingFeesAndCurseFees.add(totalProtocolFees)));
-    } catch (error) {
-      console.error(`error in fetchFeesWithRetry: ${error}`);
-      if (retryCount < maxRetries) {
-        setTimeout(() => setFeesWithRetry(retryCount + 1), retryInterval);
-      } else {
-        setFeesError(true);
+        // Calculate and set total curse fees
+        const totalCurseFeesCalc = selectedArchaeologists.reduce(
+          (acc, archaeologist) => acc.add(archaeologist.profile.curseFee),
+          ethers.constants.Zero
+        );
+        setTotalCurseFees(totalCurseFeesCalc);
+
+        // TODO -- protocol fees with curse fees should happen in the SDK
+        let totalProtocolFees;
+        if (newProtocolFee && newProtocolFeeBasePercentage) {
+          totalProtocolFees = newProtocolFee.add(
+            totalCurseFeesCalc.div(
+              BigNumber.from(10000).div(BigNumber.from(newProtocolFeeBasePercentage))
+            )
+          );
+        } else {
+          totalProtocolFees = ethers.constants.Zero;
+        }
+
+        setProtocolFee(totalProtocolFees);
+
+        // Calculate and set digging and curse fees
+        const diggingFeesAndCurseFees = newTotalDiggingFees.add(totalCurseFeesCalc);
+        dispatch(setTotalFees(diggingFeesAndCurseFees.add(totalProtocolFees)));
+      } catch (error) {
+        console.error(`error in fetchFeesWithRetry: ${error}`);
+        if (retryCount < maxRetries) {
+          setTimeout(() => setFeesWithRetry(retryCount + 1), retryInterval);
+        } else {
+          setFeesError(true);
+        }
+      } finally {
+        setAreFeesLoading(false);
       }
-    } finally {
-      setAreFeesLoading(false);
-    }
-  }, [dispatch]);
+    },
+    [dispatch, timestampMs, selectedArchaeologists, resurrection]
+  );
 
   useEffect(() => {
     setAreFeesLoading(true);

--- a/src/features/embalm/stepContent/hooks/useSarcoFees.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcoFees.ts
@@ -20,60 +20,60 @@ export function useSarcoFees() {
 
   const retryInterval = 3000; // Time in milliseconds to wait before retrying
   const maxRetries = 5; // Maximum number of retries
-    const setFeesWithRetry = async (retryCount: number = 0) => {
-      try {
-        // Get the fees
-        const {
-          totalDiggingFees: newTotalDiggingFees,
-          protocolFee: newProtocolFee,
-          formattedTotalDiggingFees: newFormattedTotalDiggingFees,
-          protocolFeeBasePercentage: newProtocolFeeBasePercentage,
-        } = await sarco.archaeologist.getTotalFeesInSarco(
-          selectedArchaeologists,
-          resurrection,
-          timestampMs
+  const setFeesWithRetry = async (retryCount: number = 0) => {
+    try {
+      // Get the fees
+      const {
+        totalDiggingFees: newTotalDiggingFees,
+        protocolFee: newProtocolFee,
+        formattedTotalDiggingFees: newFormattedTotalDiggingFees,
+        protocolFeeBasePercentage: newProtocolFeeBasePercentage,
+      } = await sarco.archaeologist.getTotalFeesInSarco(
+        selectedArchaeologists,
+        resurrection,
+        timestampMs
+      );
+
+      // Set the fees in state
+      setTotalDiggingFees(newTotalDiggingFees);
+      setFormattedTotalDiggingFees(newFormattedTotalDiggingFees);
+      setProtocolFeeBasePercentage(newProtocolFeeBasePercentage.toString());
+
+      // Calculate and set total curse fees
+      const totalCurseFeesCalc = selectedArchaeologists.reduce(
+        (acc, archaeologist) => acc.add(archaeologist.profile.curseFee),
+        ethers.constants.Zero
+      );
+      setTotalCurseFees(totalCurseFeesCalc);
+
+      // TODO -- protocol fees with curse fees should happen in the SDK
+      let totalProtocolFees;
+      if (newProtocolFee && protocolFeeBasePercentage) {
+        totalProtocolFees = newProtocolFee.add(
+          totalCurseFeesCalc.div(
+            BigNumber.from(10000).div(BigNumber.from(protocolFeeBasePercentage))
+          )
         );
-
-        // Set the fees in state
-        setTotalDiggingFees(newTotalDiggingFees);
-        setFormattedTotalDiggingFees(newFormattedTotalDiggingFees);
-        setProtocolFeeBasePercentage(newProtocolFeeBasePercentage.toString());
-
-        // Calculate and set total curse fees
-        const totalCurseFeesCalc = selectedArchaeologists.reduce(
-          (acc, archaeologist) => acc.add(archaeologist.profile.curseFee),
-          ethers.constants.Zero
-        );
-        setTotalCurseFees(totalCurseFeesCalc);
-
-        // TODO -- protocol fees with curse fees should happen in the SDK
-        let totalProtocolFees;
-        if (newProtocolFee && protocolFeeBasePercentage) {
-          totalProtocolFees = newProtocolFee.add(
-            totalCurseFeesCalc.div(
-              BigNumber.from(10000).div(BigNumber.from(protocolFeeBasePercentage))
-            )
-          );
-        } else {
-          totalProtocolFees = ethers.constants.Zero;
-        }
-
-        setProtocolFee(totalProtocolFees);
-
-        // Calculate and set digging and curse fees
-        const diggingFeesAndCurseFees = newTotalDiggingFees.add(totalCurseFeesCalc);
-        dispatch(setTotalFees(diggingFeesAndCurseFees.add(totalProtocolFees)));
-      } catch (error) {
-        console.error(`error in fetchFeesWithRetry: ${error}`);
-        if (retryCount < maxRetries) {
-          setTimeout(() => setFeesWithRetry(retryCount + 1), retryInterval);
-        } else {
-          setFeesError(true);
-        }
-      } finally {
-        setAreFeesLoading(false);
+      } else {
+        totalProtocolFees = ethers.constants.Zero;
       }
-    };
+
+      setProtocolFee(totalProtocolFees);
+
+      // Calculate and set digging and curse fees
+      const diggingFeesAndCurseFees = newTotalDiggingFees.add(totalCurseFeesCalc);
+      dispatch(setTotalFees(diggingFeesAndCurseFees.add(totalProtocolFees)));
+    } catch (error) {
+      console.error(`error in fetchFeesWithRetry: ${error}`);
+      if (retryCount < maxRetries) {
+        setTimeout(() => setFeesWithRetry(retryCount + 1), retryInterval);
+      } else {
+        setFeesError(true);
+      }
+    } finally {
+      setAreFeesLoading(false);
+    }
+  };
 
   useEffect(() => {
     setAreFeesLoading(true);

--- a/src/features/embalm/stepContent/hooks/useSarcophagusParameters.ts
+++ b/src/features/embalm/stepContent/hooks/useSarcophagusParameters.ts
@@ -68,7 +68,7 @@ export const useSarcophagusParameters = () => {
       name: 'NAME',
       value: name,
       step: Step.NameSarcophagus,
-      error: !name ? 'Your Sarchophagus needs a name' : null,
+      error: !name ? 'Your Sarcophagus needs a name' : null,
     },
     {
       name: 'RESURRECTION',
@@ -150,11 +150,11 @@ export const useSarcophagusParameters = () => {
       .every(step => getStatus(step) === StepStatus.Complete);
   };
 
-  const isError = Object.values(sarcophagusParameters).some(p => p.error);
+  const parametersError = Object.values(sarcophagusParameters).some(p => p.error);
 
   return {
     sarcophagusParameters,
     isSarcophagusFormDataComplete,
-    isError,
+    parametersError,
   };
 };

--- a/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
+++ b/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
@@ -239,6 +239,7 @@ export function CreateSarcophagus() {
                 areFeesLoading ||
                 feesError ||
                 parametersError ||
+                !formattedTotalDiggingFees || 
                 !totalDiggingFees ||
                 !protocolFee ||
                 (sarcoDeficit.gt(0) && !isBuyingSarco) ||

--- a/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
+++ b/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
@@ -34,6 +34,8 @@ import { useSarcophagusParameters } from '../hooks/useSarcophagusParameters';
 import { CreateSarcophagusStage, defaultCreateSarcophagusStages } from '../utils/createSarcophagus';
 import { useNetworkConfig } from '../../../../lib/config';
 
+// TODO -- remove need for this, see RetryCreateModal reference
+const SHOW_RETRY_CREATE_MODAL = false;
 export function CreateSarcophagus() {
   const { refreshProfiles } = useLoadArchaeologists();
   const { cancelCreateToken, retryingCreate, isBuyingSarco } = useSelector(s => s.embalmState);
@@ -196,7 +198,9 @@ export function CreateSarcophagus() {
                       )} SARCO, but required balance is ${sarco.utils.formatSarco(
                         totalFeesWithBuffer.toString()
                       )} SARCO. 
-                    You can check the box to automatically swap ${networkConfig.tokenSymbol} to purchase the required balance during the creation process.`}
+                    You can check the box to automatically swap ${
+                      networkConfig.tokenSymbol
+                    } to purchase the required balance during the creation process.`}
                 </Text>
               </Flex>
             )}
@@ -287,7 +291,7 @@ export function CreateSarcophagus() {
       )}
 
       {/* TODO -- this needs to be updated to be dynamic, currently only accounts for one error case */}
-      {retryingCreate ? (
+      {retryingCreate && SHOW_RETRY_CREATE_MODAL ? (
         <RetryCreateModal
           retryCreate={retryCreateSarcophagus}
           cancelCreation={cancelCreation}

--- a/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
+++ b/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
@@ -196,7 +196,7 @@ export function CreateSarcophagus() {
                       )} SARCO, but required balance is ${sarco.utils.formatSarco(
                         totalFeesWithBuffer.toString()
                       )} SARCO. 
-                    You can check the box to automatically swap ETH to purchase the required balance during the creation process.`}
+                    You can check the box to automatically swap ${networkConfig.tokenSymbol} to purchase the required balance during the creation process.`}
                 </Text>
               </Flex>
             )}
@@ -286,6 +286,7 @@ export function CreateSarcophagus() {
         </>
       )}
 
+      {/* TODO -- this needs to be updated to be dynamic, currently only accounts for one error case */}
       {retryingCreate ? (
         <RetryCreateModal
           retryCreate={retryCreateSarcophagus}

--- a/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
+++ b/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
@@ -32,6 +32,7 @@ import { useSarcoFees } from '../hooks/useSarcoFees';
 import { useSarcoQuote } from '../hooks/useSarcoQuote';
 import { useSarcophagusParameters } from '../hooks/useSarcophagusParameters';
 import { CreateSarcophagusStage, defaultCreateSarcophagusStages } from '../utils/createSarcophagus';
+import { useNetworkConfig } from '../../../../lib/config';
 
 export function CreateSarcophagus() {
   const { refreshProfiles } = useLoadArchaeologists();
@@ -42,6 +43,7 @@ export function CreateSarcophagus() {
   const [createSarcophagusStages, setCreateSarcophagusStages] = useState<Record<number, string>>(
     defaultCreateSarcophagusStages
   );
+  const networkConfig = useNetworkConfig();
 
   const { archaeologists } = useSelector(x => x.embalmState);
 
@@ -175,7 +177,7 @@ export function CreateSarcophagus() {
                   isChecked={isBuyingSarco}
                   onChange={handleChangeBuySarcoChecked}
                 >
-                  <Text>Swap ETH for SARCO</Text>
+                  <Text>Swap {networkConfig.tokenSymbol} for SARCO</Text>
                 </Checkbox>
                 <Text
                   mt={3}
@@ -187,7 +189,7 @@ export function CreateSarcophagus() {
                       : `${sarco.utils.formatSarco(
                           sarcoQuoteETHAmount,
                           18
-                        )} ETH will be swapped for ${sarco.utils.formatSarco(
+                        )} ${networkConfig.tokenSymbol} will be swapped for ${sarco.utils.formatSarco(
                           sarcoDeficit.toString()
                         )} SARCO before the sarcophagus is created.`
                     : `Your current SARCO balance is ${sarco.utils.formatSarco(

--- a/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
+++ b/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
@@ -49,7 +49,16 @@ export function CreateSarcophagus() {
 
   const { archaeologists } = useSelector(x => x.embalmState);
 
-  const { areFeesLoading, totalFees, formattedTotalDiggingFees, totalCurseFees, protocolFeeBasePercentage, totalDiggingFees, protocolFee, feesError } = useSarcoFees();
+  const {
+    areFeesLoading,
+    totalFees,
+    formattedTotalDiggingFees,
+    totalCurseFees,
+    protocolFeeBasePercentage,
+    totalDiggingFees,
+    protocolFee,
+    feesError,
+  } = useSarcoFees();
 
   // TODO -- buffer is temporarily removed. Determine if we need a buffer.
   // When testing, it was confusing that swap amount was more than required fees.
@@ -293,7 +302,7 @@ export function CreateSarcophagus() {
                 ml={2}
                 variant="secondary"
               >
-                = {stageError}
+                = See console for error details
               </Text>
             </Flex>
           )}

--- a/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
+++ b/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
@@ -186,10 +186,9 @@ export function CreateSarcophagus() {
                   {isBuyingSarco
                     ? sarcoQuoteError
                       ? `There was a problem getting a SARCO quote: ${sarcoQuoteError}`
-                      : `${sarco.utils.formatSarco(
-                          sarcoQuoteETHAmount,
-                          18
-                        )} ${networkConfig.tokenSymbol} will be swapped for ${sarco.utils.formatSarco(
+                      : `${sarco.utils.formatSarco(sarcoQuoteETHAmount, 18)} ${
+                          networkConfig.tokenSymbol
+                        } will be swapped for ${sarco.utils.formatSarco(
                           sarcoDeficit.toString()
                         )} SARCO before the sarcophagus is created.`
                     : `Your current SARCO balance is ${sarco.utils.formatSarco(

--- a/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
+++ b/src/features/embalm/stepContent/steps/CreateSarcophagus.tsx
@@ -49,13 +49,13 @@ export function CreateSarcophagus() {
 
   const { archaeologists } = useSelector(x => x.embalmState);
 
-  const { totalFees, totalDiggingFees, protocolFee } = useSarcoFees();
+  const { totalFees, totalDiggingFees, protocolFee, feesError } = useSarcoFees();
 
   // TODO -- buffer is temporarily removed. Determine if we need a buffer.
   // When testing, it was confusing that swap amount was more than required fees.
   const totalFeesWithBuffer = totalFees;
 
-  const { isSarcophagusFormDataComplete, isError } = useSarcophagusParameters();
+  const { isSarcophagusFormDataComplete, parametersError } = useSarcophagusParameters();
   const { balance } = useSarcoBalance();
 
   const sarcoDeficit = totalFeesWithBuffer.sub(BigNumber.from(balance));
@@ -210,11 +210,12 @@ export function CreateSarcophagus() {
               mt={6}
               onClick={handleCreate}
               isDisabled={
+                feesError ||
+                parametersError ||
                 !totalDiggingFees ||
                 !protocolFee ||
                 (sarcoDeficit.gt(0) && !isBuyingSarco) ||
-                !isSarcophagusFormDataComplete() ||
-                isError
+                !isSarcophagusFormDataComplete()
               }
             >
               Create Sarcophagus

--- a/src/features/embalm/stepContent/steps/UploadPayload.tsx
+++ b/src/features/embalm/stepContent/steps/UploadPayload.tsx
@@ -60,7 +60,7 @@ export function UploadPayload() {
         dispatch(toggleSponsorBundlr());
       }
     }
-  }, [file, dispatch, toggleSponsorBundlr]);
+  }, [file, dispatch, sponsorBundlr]);
 
   return (
     <VStack

--- a/src/features/embalm/stepContent/steps/UploadPayload.tsx
+++ b/src/features/embalm/stepContent/steps/UploadPayload.tsx
@@ -8,10 +8,13 @@ import { useUploadPayload } from '../hooks/useUploadPayload';
 import { useSupportedNetwork } from 'lib/config/useSupportedNetwork';
 import { useDispatch, useSelector } from 'store/index';
 import { toggleSponsorBundlr } from 'store/embalm/actions';
+import { useState, useEffect } from 'react';
 
+const MAX_SPONSORED_FILE_SIZE = 5000000; // 5 MB
 export function UploadPayload() {
   const { error, file, handleSetFile, fileInputRef } = useUploadPayload();
   const { formattedUploadPrice } = useUploadPrice();
+  const [canBeSponsored, setCanBeSponsored] = useState(false);
 
   const dispatch = useDispatch();
 
@@ -46,6 +49,18 @@ export function UploadPayload() {
 
   const filenameTooltip =
     !!file && file.name.length > maxSarcophagusNameLength * 2 ? file.name : '';
+
+  useEffect(() => {
+    if (file && file.size <= MAX_SPONSORED_FILE_SIZE) {
+      setCanBeSponsored(true);
+    } else {
+      setCanBeSponsored(false);
+      // If sponsored upload is true, set to false.
+      if (sponsorBundlr) {
+        dispatch(toggleSponsorBundlr());
+      }
+    }
+  }, [file]);
 
   return (
     <VStack
@@ -83,7 +98,7 @@ export function UploadPayload() {
               </Text>
             </Tooltip>
             <Text>Size: {prettyBytes(file.size)}</Text>
-            <HStack
+            {canBeSponsored ? (<HStack
               cursor={'pointer'}
               onClick={e => {
                 e.stopPropagation();
@@ -97,6 +112,9 @@ export function UploadPayload() {
               />
               <Text>Use sponsored upload</Text>
             </HStack>
+            ) : (
+              <Text fontSize='xs' as='i' variant="secondary">Max size for sponsored Bundlr file is 5MB</Text>
+            )}
             {!sponsorBundlr ? (
               <Text>
                 {"Bundlr's upload price: "}

--- a/src/features/embalm/stepContent/steps/UploadPayload.tsx
+++ b/src/features/embalm/stepContent/steps/UploadPayload.tsx
@@ -98,22 +98,29 @@ export function UploadPayload() {
               </Text>
             </Tooltip>
             <Text>Size: {prettyBytes(file.size)}</Text>
-            {canBeSponsored ? (<HStack
-              cursor={'pointer'}
-              onClick={e => {
-                e.stopPropagation();
-                dispatch(toggleSponsorBundlr());
-              }}
-            >
-              <Checkbox
-                mr={1}
-                isChecked={sponsorBundlr}
-                onChange={() => dispatch(toggleSponsorBundlr())}
-              />
-              <Text>Use sponsored upload</Text>
-            </HStack>
+            {canBeSponsored ? (
+              <HStack
+                cursor={'pointer'}
+                onClick={e => {
+                  e.stopPropagation();
+                  dispatch(toggleSponsorBundlr());
+                }}
+              >
+                <Checkbox
+                  mr={1}
+                  isChecked={sponsorBundlr}
+                  onChange={() => dispatch(toggleSponsorBundlr())}
+                />
+                <Text>Use sponsored upload</Text>
+              </HStack>
             ) : (
-              <Text fontSize='xs' as='i' variant="secondary">Max size for sponsored Bundlr file is 5MB</Text>
+              <Text
+                fontSize="xs"
+                as="i"
+                variant="secondary"
+              >
+                Max size for sponsored Bundlr file is 5MB
+              </Text>
             )}
             {!sponsorBundlr ? (
               <Text>

--- a/src/features/embalm/stepContent/steps/UploadPayload.tsx
+++ b/src/features/embalm/stepContent/steps/UploadPayload.tsx
@@ -60,7 +60,7 @@ export function UploadPayload() {
         dispatch(toggleSponsorBundlr());
       }
     }
-  }, [file]);
+  }, [file, dispatch, toggleSponsorBundlr]);
 
   return (
     <VStack

--- a/src/features/embalm/stepContent/utils/errors.ts
+++ b/src/features/embalm/stepContent/utils/errors.ts
@@ -16,7 +16,7 @@ const processArchCommsException = (offendingArchs: ArchaeologistData[]) => {
 export const createSarcophagusErrors: Record<number, string> = {
   [CreateSarcophagusStage.DIAL_ARCHAEOLOGISTS]: 'Failure Connecting to All Selected Archaeologists',
   [CreateSarcophagusStage.ARCHAEOLOGIST_NEGOTIATION]: 'Retrieving Archaeologist Signatures Failed',
-  [CreateSarcophagusStage.BUY_SARCO]: 'Failed to swap ETH for SARCO',
+  [CreateSarcophagusStage.BUY_SARCO]: 'Failed to swap for SARCO',
   [CreateSarcophagusStage.UPLOAD_PAYLOAD]: 'Upload File Data to Arweave Failed',
   [CreateSarcophagusStage.APPROVE]: 'Approval Failed',
   [CreateSarcophagusStage.SUBMIT_SARCOPHAGUS]: 'Create Sarcophagus Failed',

--- a/src/hooks/sarcoToken/useAllowance.ts
+++ b/src/hooks/sarcoToken/useAllowance.ts
@@ -13,26 +13,29 @@ export function useAllowance() {
   const retryInterval = 3000; // Time in milliseconds to wait before retrying
   const maxRetries = 4; // Maximum number of retries
 
-  const fetchAllowanceWithRetry = useCallback(async (retryCount: number = 0) => {
-    if (!address) return;
-    setIsLoading(true);
-    try {
-      const fetchedAllowance = await sarco.token.allowance(address);
-      setAllowance(fetchedAllowance);
-      setError(null);
-      setAllowanceError(false);
-    } catch (e) {
-      const err = e as Error;
-      if (retryCount < maxRetries) {
-        setTimeout(() => fetchAllowanceWithRetry(retryCount + 1), retryInterval);
-      } else {
-        setError(err.message);
-        setAllowanceError(true);
+  const fetchAllowanceWithRetry = useCallback(
+    async (retryCount: number = 0) => {
+      if (!address) return;
+      setIsLoading(true);
+      try {
+        const fetchedAllowance = await sarco.token.allowance(address);
+        setAllowance(fetchedAllowance);
+        setError(null);
+        setAllowanceError(false);
+      } catch (e) {
+        const err = e as Error;
+        if (retryCount < maxRetries) {
+          setTimeout(() => fetchAllowanceWithRetry(retryCount + 1), retryInterval);
+        } else {
+          setError(err.message);
+          setAllowanceError(true);
+        }
+      } finally {
+        setIsLoading(false);
       }
-    } finally {
-      setIsLoading(false);
-    }
-  }, [address]);
+    },
+    [address]
+  );
 
   useEffect(() => {
     fetchAllowanceWithRetry();

--- a/src/hooks/sarcoToken/useAllowance.ts
+++ b/src/hooks/sarcoToken/useAllowance.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { sarco } from '@sarcophagus-org/sarcophagus-v2-sdk-client';
 import { useAccount } from 'wagmi';
 
@@ -13,7 +13,7 @@ export function useAllowance() {
   const retryInterval = 3000; // Time in milliseconds to wait before retrying
   const maxRetries = 4; // Maximum number of retries
 
-  const fetchAllowanceWithRetry = async (retryCount: number = 0) => {
+  const fetchAllowanceWithRetry = useCallback(async (retryCount: number = 0) => {
     if (!address) return;
     setIsLoading(true);
     try {
@@ -32,7 +32,7 @@ export function useAllowance() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [address]);
 
   useEffect(() => {
     fetchAllowanceWithRetry();

--- a/src/hooks/sarcoToken/useAllowance.ts
+++ b/src/hooks/sarcoToken/useAllowance.ts
@@ -7,7 +7,7 @@ export function useAllowance() {
   const { address } = useAccount();
   const [allowance, setAllowance] = useState<BigNumber | undefined>();
   const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
+  const [allowanceError, setAllowanceError] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -18,12 +18,12 @@ export function useAllowance() {
         const fetchedAllowance = await sarco.token.allowance(address);
         setAllowance(fetchedAllowance);
         setError(null);
-        setIsError(false);
+        setAllowanceError(false);
       } catch (e) {
         console.error(`error fetching allowance ${e}`);
         const err = e as Error;
         setError(err.message);
-        setIsError(true);
+        setAllowanceError(true);
       } finally {
         setIsLoading(false);
       }
@@ -32,5 +32,5 @@ export function useAllowance() {
     fetchAllowance();
   }, [address]);
 
-  return { allowance, isLoading, isError, error };
+  return { allowance, isLoading, allowanceError, error };
 }

--- a/src/hooks/sarcoToken/useAllowance.ts
+++ b/src/hooks/sarcoToken/useAllowance.ts
@@ -36,7 +36,7 @@ export function useAllowance() {
 
   useEffect(() => {
     fetchAllowanceWithRetry();
-  }, [address]);
+  }, [address, fetchAllowanceWithRetry]);
 
   return { allowance, isAllowanceLoading: isLoading, allowanceError, error };
 }

--- a/src/hooks/sarcoToken/useAllowance.ts
+++ b/src/hooks/sarcoToken/useAllowance.ts
@@ -20,6 +20,7 @@ export function useAllowance() {
         setError(null);
         setIsError(false);
       } catch (e) {
+        console.error(`error fetching allowance ${e}`);
         const err = e as Error;
         setError(err.message);
         setIsError(true);

--- a/src/hooks/sarcoToken/useApprove.ts
+++ b/src/hooks/sarcoToken/useApprove.ts
@@ -19,8 +19,8 @@ export function useApprove(args: { onApprove?: Function; amount: BigNumber }) {
     } catch (e) {
       const err = e as Error;
       console.error(err);
-      setError(err.message);
       toast(approveFailure());
+      throw new Error(err.message || 'Error Approving SARCO token');
     } finally {
       setIsApproving(false);
     }

--- a/src/hooks/sarcoToken/useApprove.ts
+++ b/src/hooks/sarcoToken/useApprove.ts
@@ -19,6 +19,7 @@ export function useApprove(args: { onApprove?: Function; amount: BigNumber }) {
     } catch (e) {
       const err = e as Error;
       console.error(err);
+      setError(err.message);
       toast(approveFailure());
       throw new Error(err.message || 'Error Approving SARCO token');
     } finally {

--- a/src/hooks/sarcoToken/useSarcoBalance.ts
+++ b/src/hooks/sarcoToken/useSarcoBalance.ts
@@ -27,7 +27,7 @@ export function useSarcoBalance() {
   return {
     balance: data as BigNumber | undefined,
     formattedBalance,
-    isError,
+    balanceError: isError,
     isLoading,
   };
 }

--- a/src/hooks/useTimestampMs.ts
+++ b/src/hooks/useTimestampMs.ts
@@ -15,5 +15,11 @@ export function useTimestampMs() {
 
   useEffect(() => {
     getTimestampMs();
+
+    const interval = setInterval(() => {
+      getTimestampMs();
+    }, 10 * 60 * 1000); // refetch every 10 minutes
+
+    return () => clearInterval(interval);
   }, [getTimestampMs]);
 }

--- a/src/lib/network/WalletProvider.tsx
+++ b/src/lib/network/WalletProvider.tsx
@@ -4,14 +4,7 @@ import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { publicProvider } from 'wagmi/providers/public';
 import { infuraProvider } from 'wagmi/providers/infura';
 import { walletConnectionTheme } from '../../theme/walletConnectionTheme';
-import {
-  sepolia,
-  mainnet,
-  hardhat,
-  polygonMumbai,
-  arbitrum,
-  polygon,
-} from '@wagmi/core/chains';
+import { sepolia, mainnet, hardhat, polygonMumbai, arbitrum, polygon } from '@wagmi/core/chains';
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
   const { chains, provider } = configureChains(


### PR DESCRIPTION
## Overview
Patch a few bugs and make a few UX tweaks.

1. Add retries for a few RPC calls to give some buffer for failures. The SDK needs to be examined/updated to improve RPC performance (less calls / better error handling).

2. Disallow sponsored uploads > 5MB

3. Update the current gobal blocktime to get re-polled every 10 minutes (currently only gets set once per session).

4. Throw error if approval step fails. Currently it would continue to the next step automatically in the create process if approval failed.

5. Temporarily disable the create retry modal. This modal was setup to handle a specific error case, but needs to handle multiple so can confuse the user (and be a red herring).

See other commit messages for a few other small changes.